### PR TITLE
feat: proxy endpoint for unimplemented api

### DIFF
--- a/server/routes/gh/[...slug].ts
+++ b/server/routes/gh/[...slug].ts
@@ -1,0 +1,9 @@
+import { ghFetch } from '~/utils/github'
+
+export default eventHandler(async (event) => {
+  const result = await ghFetch(event.context.params.slug || '')
+
+  return {
+    result
+  }
+})


### PR DESCRIPTION
This PR hopes to add an endpoint that would use APIs that aren't implemented yet. It's available if really needed, and a notice can be added to discourage usage if required!