### PR TITLE
feat: add `defaultBranch` and use it for `readme` endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ GitHub repository information.
     "pushedAt": "2022-11-06T06:48:23Z",
     "stars": 1168,
     "watchers": 1168,
-    "forks": 59
+    "forks": 59,
+    "defaultBranch": "main"
   }
 }
 ```

--- a/routes/repos/[owner]/[repo]/index.ts
+++ b/routes/repos/[owner]/[repo]/index.ts
@@ -16,6 +16,7 @@ export default eventHandler(async (event) => {
     stars: rawRepo.stargazers_count,
     watchers: rawRepo.watchers,
     forks: rawRepo.forks,
+    defaultBranch: rawRepo.default_branch,
   };
 
   return {

--- a/routes/repos/[owner]/[repo]/readme.ts
+++ b/routes/repos/[owner]/[repo]/readme.ts
@@ -1,8 +1,11 @@
 export default cachedEventHandler(
   async (event) => {
     const repo = `${event.context.params.owner}/${event.context.params.repo}`;
+    const defaultBranch = await ghRepo(repo).then(
+      (r) => r.default_branch || "main",
+    );
     const markdown = await $fetch<string>(
-      `https://raw.githubusercontent.com/${repo}/main/README.md`,
+      `https://raw.githubusercontent.com/${repo}/${defaultBranch}/README.md`,
     );
     const html = await ghMarkdown(markdown, repo, "readme");
     return {

--- a/types/index.ts
+++ b/types/index.ts
@@ -9,6 +9,7 @@ export interface GithubRepo {
   stars: number;
   watchers: number;
   forks: number;
+  defaultBranch: string;
 }
 
 export interface GithubOrg {


### PR DESCRIPTION
Add default branch filed in GithubRepo interface.

Get readme from default branch if there is not a branch query.