### PR TITLE
fix: relative link replacement

### DIFF
--- a/routes/repos/[owner]/[repo]/readme.ts
+++ b/routes/repos/[owner]/[repo]/readme.ts
@@ -1,3 +1,4 @@
+const GH_PATH_URL = "https://github.com";
 const GH_RAW_URL = "https://raw.githubusercontent.com";
 
 export default cachedEventHandler(
@@ -6,12 +7,19 @@ export default cachedEventHandler(
     const defaultBranch = await ghRepo(repo).then(
       (r) => r.default_branch || "main",
     );
-    const cdnBaseURL = `${GH_RAW_URL}/${repo}/${defaultBranch}`;
-    const markdown = await $fetch<string>(`${cdnBaseURL}/README.md`);
+
+    const linkOptions = {
+      cdnBaseURL: `${GH_RAW_URL}/${repo}/${defaultBranch}`,
+      githubBaseURL: `${GH_PATH_URL}/${repo}/tree/${defaultBranch}`,
+    };
+    const markdown = await $fetch<string>(
+      `${linkOptions.cdnBaseURL}/README.md`,
+    );
     const html = await ghMarkdown(markdown, repo, "readme");
+
     return {
-      markdown: resolveMarkdownRelativeLinks(markdown, cdnBaseURL),
-      html: resolveMarkdownRelativeLinks(html, cdnBaseURL),
+      markdown: resolveMarkdownRelativeLinks(markdown, linkOptions),
+      html: resolveMarkdownRelativeLinks(html, linkOptions),
     };
   },
   {

--- a/utils/markdown.ts
+++ b/utils/markdown.ts
@@ -1,22 +1,30 @@
-const MARKDOWN_LINK_RE =
-  /(?<link>\[.*?]\((?<url>.*?)\)|<img.*?src="(?<url2>.*?)".*?>)/g;
+const HTML_LINK_RE = /(<img.*?src="(?<url2>.*?)".*?>)/g;
+const MARKDOWN_LINK_RE = /(?<link>\[.*?]\((?<url>.*?)\))/g;
 
 /**
- * HTML & Mardown Function to replace relative image paths with absolute paths
+ * Creates a string replacement function, prefixing matched strings with `baseURL`
+ */
+function createReplacerFn(baseURL: string) {
+  return (match, _, url: string | undefined, url2: string) => {
+    const path = url || url2;
+    // If path is already a URL, return the match
+    if (path.startsWith("http") || path.startsWith("https")) {
+      return match;
+    }
+    return match.replace(path, `${baseURL}/${path.replace(/^\.\//, "")}`);
+  };
+}
+
+/**
+ * HTML & Mardown Function to replace relative paths with absolute paths
+ * - prefixes relative image paths with `cdnBaseURL`
+ * - prefixes relative markdown paths with `ghBaseURL`
  */
 export function resolveMarkdownRelativeLinks(
   content: string,
-  cdnBaseURL: string,
+  options: { cdnBaseURL: string; githubBaseURL: string },
 ) {
-  return content.replace(
-    MARKDOWN_LINK_RE,
-    (match, _, url: string | undefined, url2: string) => {
-      const path = url || url2;
-      // If path is already a URL, return the match
-      if (path.startsWith("http") || path.startsWith("https")) {
-        return match;
-      }
-      return match.replace(path, `${cdnBaseURL}/${path.replace(/^\.\//, "")}`);
-    },
-  );
+  return content
+    .replace(HTML_LINK_RE, createReplacerFn(options.cdnBaseURL))
+    .replace(MARKDOWN_LINK_RE, createReplacerFn(options.githubBaseURL));
 }


### PR DESCRIPTION
Resolves #94 

This changes the relative link replacement, only image asset URLs are replaced/prefixed with the raw Github URL, while relative markdown URLs are simply replaced/prefixed with a normal (absolute) link to the branch tree.

Code is a bit messier with my changes 😅 happy to receive feedback.