### PR TITLE
ci: fix corepack

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: corepack enable
+      - run: npm i -fg corepack && corepack enable
       - uses: actions/setup-node@v4
         with:
           node-version: 18

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: corepack enable
+      - run: npm i -fg corepack && corepack enable
       - uses: actions/setup-node@v4
         with:
           node-version: 18


### PR DESCRIPTION
Similar to the workflow files in `h3`, should we also update these workflows to use node 20/22?