### PR TITLE
feat: change to enable token pool

### DIFF
--- a/nitro.config.ts
+++ b/nitro.config.ts
@@ -3,6 +3,7 @@ import { defineNitroConfig } from "nitropack/config";
 export default defineNitroConfig({
   runtimeConfig: {
     GH_TOKEN: process.env.GH_TOKEN,
+    GH_TOKEN2: process.env.GH_TOKEN2,
   },
   routeRules: {
     "/**": {

--- a/utils/github.ts
+++ b/utils/github.ts
@@ -15,16 +15,84 @@ const cacheOptions = (name: string): CacheOptions => ({
   name,
 });
 
+type RatelimitInformation = {
+  /**
+   * The number of requests remaining in the current rate limit window.
+   * This is collected from the response `x-ratelimit-remaining` header.
+   * See https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#checking-the-status-of-your-rate-limit
+   */
+  remaining: number;
+  /**
+   * The time at which the current rate limit window resets, in UTC epoch seconds.
+   * This is collected from the response `x-ratelimit-reset` header.
+   * See https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#checking-the-status-of-your-rate-limit
+   */
+  reset: number;
+};
+/**
+ * Holds the ratelimit information per GitHub token.
+ * This is collected from the response header.
+ * See https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#checking-the-status-of-your-rate-limit
+ */
+const ratelimitInfos = new Map<string, RatelimitInformation>();
+
+/**
+ * Returns the GitHub token with the highest remaining rate limit.
+ * If no tokens are available, it defaults to the first token.
+ */
+function getGhTokenWithHighRatelimitRemaining(): string {
+  const now = Math.floor(Date.now() / 1000);
+  const tokenWithRemaining = [runtimeConfig.GH_TOKEN, runtimeConfig.GH_TOKEN2]
+    .filter(Boolean)
+    .map((token) => {
+      const ratelimitInfo = ratelimitInfos.get(token);
+      return {
+        token,
+        remaining:
+          ratelimitInfo && ratelimitInfo.reset > now
+            ? ratelimitInfo.remaining
+            : Infinity,
+      };
+    });
+  let candidate: { token: string; remaining: number } | undefined;
+  for (const token of tokenWithRemaining) {
+    if (!candidate || token.remaining > candidate.remaining) {
+      candidate = token;
+    }
+  }
+  return candidate?.token;
+}
+
 export const ghFetch = cachedFunction(
   <T = any>(url: string, opts: FetchOptions = {}) => {
+    const ghToken = getGhTokenWithHighRatelimitRemaining();
     return $fetch<T>(url, {
       baseURL: "https://api.github.com",
       ...opts,
       method: (opts.method || "GET").toUpperCase() as any,
       headers: {
         "User-Agent": "fetch",
-        Authorization: "token " + runtimeConfig.GH_TOKEN,
+        Authorization: "token " + ghToken,
         ...opts.headers,
+      },
+      async onResponse({ response }) {
+        const rawRemaining = response.headers.get("x-ratelimit-remaining");
+        const rawReset = response.headers.get("x-ratelimit-reset");
+        if (!rawRemaining || !rawReset) {
+          // If the header value is not what is expected, we can't do anything
+          return;
+        }
+        const remaining = Number(rawRemaining);
+        const reset = Number(rawReset);
+        if (Number.isNaN(remaining) || Number.isNaN(reset)) {
+          // If the header value is not what is expected, we can't do anything
+          return;
+        }
+
+        ratelimitInfos.set(ghToken, {
+          remaining,
+          reset,
+        });
       },
     });
   },


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

related to #5

This PR will improve the server to make the token pool available.



**About the implementation:**


Currently the implementation makes the second token available through the GH_TOKEN2 environment variable, but that can be changed. Please let me know your preferred way of defining it.


The priority for using tokens is the token with the most remaining rate limit window. However, since the number of tokens is not known until each token is used to make a request, they are used in order regardless of the rate limit window.


**Additional comments:**


We are still discussing how to collect the token pool in #5, so I don't think this PR change alone will enable the token pool, but I would be happy if I could contribute the first step.

