### PR TITLE
feat: support repo issue and pull count

### DIFF
--- a/routes/orgs/[owner]/repos.ts
+++ b/routes/orgs/[owner]/repos.ts
@@ -33,6 +33,7 @@ export default eventHandler(async (event) => {
         stars: rawRepo.stargazers_count,
         watchers: rawRepo.watchers,
         forks: rawRepo.forks,
+        issueAndPullCount: rawRepo.open_issues_count,
         defaultBranch: rawRepo.default_branch,
       },
   );

--- a/routes/repos/[owner]/[repo]/index.ts
+++ b/routes/repos/[owner]/[repo]/index.ts
@@ -2,7 +2,7 @@ import type { GithubRepo } from "~types";
 
 defineRouteMeta({
   openAPI: {
-    description: "Get repository readme file on main branch (not cached).",
+    description: "Get repository info.",
     parameters: [
       {
         name: "owner",
@@ -35,6 +35,7 @@ export default eventHandler(async (event) => {
     stars: rawRepo.stargazers_count,
     watchers: rawRepo.subscribers_count,
     forks: rawRepo.forks,
+    issueAndPullCount: rawRepo.open_issues_count,
     defaultBranch: rawRepo.default_branch,
   };
 

--- a/routes/repos/[owner]/[repo]/issue-count.ts
+++ b/routes/repos/[owner]/[repo]/issue-count.ts
@@ -1,0 +1,31 @@
+defineRouteMeta({
+  openAPI: {
+    description: "Get repository open issues count.",
+    parameters: [
+      {
+        name: "owner",
+        in: "path",
+        required: true,
+        schema: { type: "string", example: "unjs" },
+      },
+      {
+        name: "repo",
+        in: "path",
+        required: true,
+        schema: { type: "string", example: "ofetch" },
+      },
+    ],
+  },
+});
+
+export default eventHandler(async (event) => {
+  const res = await ghFetch(
+    `/search/issues?q=repo:${event.context.params.owner}/${event.context.params.repo}+type:issue+state:open&per_page=1`,
+  );
+
+  const count = res.total_count;
+
+  return {
+    count,
+  };
+});

--- a/routes/repos/[owner]/[repo]/pull-count.ts
+++ b/routes/repos/[owner]/[repo]/pull-count.ts
@@ -1,0 +1,31 @@
+defineRouteMeta({
+  openAPI: {
+    description: "Get repository open pull requests count.",
+    parameters: [
+      {
+        name: "owner",
+        in: "path",
+        required: true,
+        schema: { type: "string", example: "unjs" },
+      },
+      {
+        name: "repo",
+        in: "path",
+        required: true,
+        schema: { type: "string", example: "ofetch" },
+      },
+    ],
+  },
+});
+
+export default eventHandler(async (event) => {
+  const res = await ghFetch(
+    `/search/issues?q=repo:${event.context.params.owner}/${event.context.params.repo}+type:pr+state:open&per_page=1`,
+  );
+
+  const count = res.total_count;
+
+  return {
+    count,
+  };
+});

--- a/routes/users/[name]/repos.ts
+++ b/routes/users/[name]/repos.ts
@@ -32,6 +32,7 @@ export default eventHandler(async (event) => {
         stars: rawRepo.stargazers_count,
         watchers: rawRepo.watchers,
         forks: rawRepo.forks,
+        issueAndPullCount: rawRepo.open_issues_count,
         defaultBranch: rawRepo.default_branch,
       },
   );

--- a/types/index.ts
+++ b/types/index.ts
@@ -9,6 +9,7 @@ export interface GithubRepo {
   stars: number;
   watchers: number;
   forks: number;
+  issueAndPullCount: number;
   defaultBranch: string;
 }
 


### PR DESCRIPTION
closes #148

New endpoints:
- `/repos/[owner]/[repo]/issue-count` => `{ count: number }`
- `/repos/[owner]/[repo]/pull-count` => `{ count: number }`

Updated endpoints:
- `/repos/[owner]/[repo]` returns new `issueAndPullCount` field (combined open issues and PRs count returned by github)

## Thoughts needed

In #148 I mentioned using the Link header trick to retrieve the issue and pr count quickly, but it only works if the repo has more than 1 issues or prs for the header to appear (for pagination). So I went with the github search approach, however that has a [stricter rate limit](https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#rate-limit): 1800/hour instead of 5000/hour, however this is a separate rate limit bucket to the core apis.

Alternatively, we can use the graphql api to fetch the issue and pr count, which i calculate has a lower cost ([and better rate limit](https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api#primary-rate-limit)) altogether (1 point per query), but at that point, maybe `/repos/[owner]/[repo]` should just use the graphql api and fetch everything in one go?

Any thoughts on how we should go from here? Or is the current implementation good enough?

<details>
<summary>Example graphql query test</summary>

```
curl -H "Authorization: Bearer YOUR_GITHUB_TOKEN" \
  -H "Content-Type: application/json" \
  -X POST https://api.github.com/graphql \
  -d '{
    "query": "query RepoInfo($owner: String!, $name: String!) { repository(owner: $owner, name: $name) { id name nameWithOwner description createdAt updatedAt pushedAt stargazerCount watchers { totalCount } forkCount issues(states: OPEN) { totalCount } pullRequests(states: OPEN) { totalCount } defaultBranchRef { name } } rateLimit { cost remaining resetAt } }",
    "variables": {
      "owner": "unjs",
      "name": "ofetch"
    }
  }'
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository info now includes an aggregated open issue + pull request count.
  * New endpoint to fetch the open issue count for a repository.
  * New endpoint to fetch the open pull request count for a repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->