### PR TITLE
feat: support repo issue and pull count with graphql

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,16 @@
     "eslint": "^9.37.0",
     "eslint-config-unjs": "^0.5.0",
     "nitropack": "npm:nitropack-nightly@2.12.5-20250819-230311.89278001",
+    "ohash": "^2.0.11",
     "openapi-renderer": "^0.1.1",
     "prettier": "^3.6.2",
     "std-env": "^3.9.0",
     "typescript": "^5.9.3"
   },
-  "packageManager": "pnpm@10.18.0"
+  "packageManager": "pnpm@10.18.0",
+  "pnpm": {
+    "overrides": {
+      "nitropack-nightly>h3": "npm:h3-nightly@1.15.5-20251001-082059-b4dce71"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  nitropack-nightly>h3: npm:h3-nightly@1.15.5-20251001-082059-b4dce71
+
 importers:
 
   .:
@@ -20,6 +23,9 @@ importers:
       nitropack:
         specifier: npm:nitropack-nightly@2.12.5-20250819-230311.89278001
         version: nitropack-nightly@2.12.5-20250819-230311.89278001(@netlify/blobs@9.1.2)(@upstash/redis@1.35.4)
+      ohash:
+        specifier: ^2.0.11
+        version: 2.0.11
       openapi-renderer:
         specifier: ^0.1.1
         version: 0.1.1

--- a/routes/orgs/[owner]/repos.ts
+++ b/routes/orgs/[owner]/repos.ts
@@ -1,4 +1,4 @@
-import type { GithubRepo } from "~types";
+import type { GithubRepoWithoutIssuesPRs } from "~types";
 
 defineRouteMeta({
   openAPI: {
@@ -22,7 +22,7 @@ export default eventHandler(async (event) => {
 
   const repos = rawRepos.map(
     (rawRepo) =>
-      <GithubRepo>{
+      <GithubRepoWithoutIssuesPRs>{
         id: rawRepo.id,
         name: rawRepo.name,
         repo: rawRepo.full_name,

--- a/routes/repos/[owner]/[repo]/index.ts
+++ b/routes/repos/[owner]/[repo]/index.ts
@@ -2,7 +2,7 @@ import type { GithubRepo } from "~types";
 
 defineRouteMeta({
   openAPI: {
-    description: "Get repository readme file on main branch (not cached).",
+    description: "Get repository info.",
     parameters: [
       {
         name: "owner",
@@ -21,21 +21,55 @@ defineRouteMeta({
 });
 
 export default eventHandler(async (event) => {
-  const rawRepo = await ghRepo(
-    `${event.context.params.owner}/${event.context.params.repo}`,
+  const { repository } = await ghGraphql(
+    /* GraphQL */ `
+      query RepoInfo($owner: String!, $name: String!) {
+        repository(owner: $owner, name: $name) {
+          id
+          databaseId
+          name
+          nameWithOwner
+          description
+          createdAt
+          updatedAt
+          pushedAt
+          stargazerCount
+          watchers {
+            totalCount
+          }
+          forkCount
+          issues(states: OPEN) {
+            totalCount
+          }
+          pullRequests(states: OPEN) {
+            totalCount
+          }
+          defaultBranchRef {
+            name
+          }
+        }
+      }
+    `,
+    {
+      owner: event.context.params.owner,
+      name: event.context.params.repo,
+    },
   );
+
   const repo = <GithubRepo>{
-    id: rawRepo.id,
-    name: rawRepo.name,
-    repo: rawRepo.full_name,
-    description: rawRepo.description,
-    createdAt: rawRepo.created_at,
-    updatedAt: rawRepo.updated_at,
-    pushedAt: rawRepo.pushed_at,
-    stars: rawRepo.stargazers_count,
-    watchers: rawRepo.subscribers_count,
-    forks: rawRepo.forks,
-    defaultBranch: rawRepo.default_branch,
+    id: repository.databaseId,
+    name: repository.name,
+    repo: repository.nameWithOwner,
+    description: repository.description,
+    createdAt: repository.createdAt,
+    updatedAt: repository.updatedAt,
+    pushedAt: repository.pushedAt,
+    stars: repository.stargazerCount,
+    watchers: repository.watchers.totalCount,
+    forks: repository.forkCount,
+    issues: repository.issues.totalCount,
+    pullRequests: repository.pullRequests.totalCount,
+    defaultBranch: repository.defaultBranchRef.name,
   };
 
   return {

--- a/routes/users/[name]/repos.ts
+++ b/routes/users/[name]/repos.ts
@@ -1,4 +1,4 @@
-import type { GithubRepo } from "~types";
+import type { GithubRepoWithoutIssuesPRs } from "~types";
 
 defineRouteMeta({
   openAPI: {
@@ -21,7 +21,7 @@ export default eventHandler(async (event) => {
 
   const repos = rawRepos.map(
     (rawRepo) =>
-      <GithubRepo>{
+      <GithubRepoWithoutIssuesPRs>{
         id: rawRepo.id,
         name: rawRepo.name,
         repo: rawRepo.full_name,

--- a/types/index.ts
+++ b/types/index.ts
@@ -14,6 +14,11 @@ export interface GithubRepo {
   defaultBranch: string;
 }
 
+export type GithubRepoWithoutIssuesPRs = Omit<
+  GithubRepo,
+  "issues" | "pullRequests"
+>;
+
 export interface GithubOrg {
   id: number;
   name: string;

--- a/types/index.ts
+++ b/types/index.ts
@@ -9,6 +9,8 @@ export interface GithubRepo {
   stars: number;
   watchers: number;
   forks: number;
+  issues: number;
+  pullRequests: number;
   defaultBranch: string;
 }
 

--- a/utils/github.ts
+++ b/utils/github.ts
@@ -1,5 +1,6 @@
 import type { CacheOptions } from "nitropack";
 import type { FetchOptions } from "ofetch";
+import { hash } from "ohash";
 
 const runtimeConfig = useRuntimeConfig();
 
@@ -142,5 +143,37 @@ export const ghMarkdown = cachedFunction(
   {
     ...cacheOptions("markdown"),
     getKey: (_markdown, repo, id) => repo + "/" + id,
+  },
+);
+
+export const ghGraphql = cachedFunction(
+  async (query: string, variables: Record<string, any> = {}) => {
+    const res = await ghFetch("/graphql", {
+      method: "POST",
+      headers: {
+        accept: "application/vnd.github+json",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        query,
+        variables,
+      }),
+    });
+
+    if (res.errors) {
+      throw createError({
+        // Hide errors in case they contain sensitive info
+        message: "GitHub GraphQL error",
+        statusCode: 500,
+      });
+    }
+
+    return res.data;
+  },
+  {
+    ...cacheOptions("graphql"),
+    getKey(query, variables) {
+      return hash(query + JSON.stringify(variables));
+    },
   },
 );


### PR DESCRIPTION
closes #148 

alternative to #149

Refactors `/repos/[owner]/[repo]` to fetch with graphql and return the issue and pr count. The cost of this graphql query is 1 point, which is part of the[ 5000 points/hour rate limit](https://docs.github.com/en/graphql/overview/rate-limits-and-query-limits-for-the-graphql-api#primary-rate-limit) for authenticated requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository info endpoint now returns more comprehensive data, including issue and pull request counts and additional repository metadata for richer insights.

* **Chores**
  * Updated tooling/dependency configuration to support the improved data retrieval and caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->