### PR TITLE
fix: improve token revalidation handling

### DIFF
--- a/.agents/GH_API.md
+++ b/.agents/GH_API.md
@@ -18,8 +18,7 @@ Two files handle all GitHub API interaction:
 ## Token Selection (`getGHToken`)
 
 1. Clear expired rate limits (reset time has passed -> wipe remaining/limit/reset)
-2. Filter to `available` tokens: `valid === true && (remaining ?? 1) > 0`
-3. Sort by highest `remaining` -> pick first
+2. Single-pass scan for `available` token with highest `remaining`
 
 ## Token Lifecycle
 
@@ -37,34 +36,46 @@ clearExpiredLimits()        -> once reset time passes, clears remaining/limit/re
                                so the token becomes available again (remaining ?? 1 > 0)
 ```
 
+## Token Acquisition (`acquireGHToken`)
+
+Main entry point used by `ghFetch`. Orchestrates the full flow:
+
+1. `ensureTokensValidated()` — one-time initial validation (idempotent, `once: true`)
+2. `getGHToken()` — pick best available token
+3. If none available, `revalidateGHTokens()` — re-check stale tokens, then `getGHToken()` again
+4. Returns token or `undefined`
+
 ## Validation Flow
 
 ### `ensureTokensValidated` (normal requests)
 
-Called once per request cycle (idempotent via `_validatePromise`):
+Runs once via `idempotent()` wrapper (`once: true` — never re-runs after first call):
 
-1. Race all PAT validations and App token bootstrap in parallel — resolve as soon as any token is available
-2. If no token available after race, falls back to `revalidateGHTokens()`
+1. Validate all PAT tokens and bootstrap App tokens in parallel via `Promise.allSettled`
+2. If no token available after validation, falls back to `revalidateGHTokens()`
+
+Subsequent requests rely on `revalidateGHTokens()` (called from `acquireGHToken`) for freshness.
 
 ### `ensureAllTokensValidated` (status page only)
 
+Runs once via `idempotent()` wrapper (`once: true`):
+
 1. Validate all PAT tokens in parallel (each calls GET /meta — costs 1 API request)
 2. Bootstrap App tokens (JWT -> list installations -> create installation tokens)
-3. Revalidate any stale tokens
 
 ## Revalidation (`revalidateGHTokens`)
 
-- Concurrent callers share one in-flight promise (coalesced)
+- Uses `idempotent()` with `once: false` — concurrent callers share one in-flight promise, but settles between calls
 - Only revalidates tokens where `isStale()` is true
 - Also calls `ensureAppToken()` to refresh app tokens if needed
 - Short-circuits if no tokens are stale AND at least one token is available
 
 ## Cached Fetch (`ghFetch`)
 
-- Wraps `ofetch` with GitHub auth headers
+- Wraps `fetch` with GitHub auth headers
 - Uses `defineCachedFunction` (6h maxAge, 12h staleMaxAge, no SWR)
-- On every response, updates the token's rate limit via `onResponse`
-- If no token available, attempts revalidation once, then throws 403
+- Calls `acquireGHToken()` to get a token; if none returned, throws 403 with diagnostic info (invalid count, exhausted count, soonest reset time)
+- On every response, updates the token's rate limit via `onResponse` → `token.updateStatus()`
 - Cache validation rejects empty arrays and zero-count results
 
 ## Helper Endpoints
@@ -78,9 +89,20 @@ Called once per request cycle (idempotent via `_validatePromise`):
 
 HTML dashboard showing per-token and aggregate rate limit usage with color-coded bars.
 
+## Concurrency: `idempotent()` utility
+
+Wraps an async function so concurrent callers share a single in-flight promise:
+
+- `once: true` (default) — runs at most once; subsequent calls return cached result. Has `.reset()` to clear.
+- `once: false` — concurrent calls share one execution, but after it settles a new call triggers a fresh run.
+
+Used by: `ensureTokensValidated` (once), `ensureAllTokensValidated` (once), `ensureAppToken` (not once — coalesced), `revalidateGHTokens` (not once — coalesced).
+
 ## Key Design Decisions
 
 - `valid !== false` (not `valid === true`) in `clearExpiredLimits` — allows clearing rate limits for never-validated tokens that have stale rate limit state
 - `remaining ?? 1` in `available` getter — treats never-checked tokens as available (optimistic until proven otherwise)
 - App token refresh is self-scheduling via `setTimeout`, not driven by requests
 - Transport errors in `validate()` preserve last-known state (no flip to invalid)
+- `updateStatus()` only updates `remaining`/`limit`/`reset` when their respective headers are present — avoids losing known state on responses lacking rate limit headers
+- `isStale()` always returns `true` for never-validated tokens (`_lastValidated` undefined), even if `reset` is somehow set — prevents edge case where a token could become permanently non-revalidatable

--- a/.agents/GH_API.md
+++ b/.agents/GH_API.md
@@ -1,0 +1,86 @@
+# GitHub API Token & Request System
+
+## Architecture
+
+Two files handle all GitHub API interaction:
+
+- `utils/github_token.ts` — Token lifecycle (validation, rotation, rate-limit tracking, GitHub App JWT)
+- `utils/github.ts` — Cached fetch layer built on top of the token system
+
+## Token Types
+
+1. **PAT tokens** — Loaded from `GH_TOKEN` env var (comma-separated). Created at module load time.
+2. **GitHub App tokens** — Generated from `GH_APP_ID` + `GH_APP_PRIVATE_KEY` env vars.
+   - JWT signed with RS256 (PKCS#1 and PKCS#8 PEM keys supported)
+   - Installation tokens fetched for each app installation
+   - Auto-refresh via `setTimeout` 5 minutes before expiry (minimum 1 minute)
+
+## Token Selection (`getGHToken`)
+
+1. Clear expired rate limits (reset time has passed -> wipe remaining/limit/reset)
+2. Filter to `available` tokens: `valid === true && (remaining ?? 1) > 0`
+3. Sort by highest `remaining` -> pick first
+
+## Token Lifecycle
+
+```
+new GHToken(token)          -> valid=undefined, remaining=undefined
+  |
+validate()                  -> calls GET /meta, sets valid/remaining/limit/reset
+  |
+updateStatus(response)      -> called on every ghFetch response to keep rate limits current
+  |
+isStale()                   -> true if: no lastValidated, or >1min since last validation
+                               (skips revalidation if reset is still in the future)
+  |
+clearExpiredLimits()        -> once reset time passes, clears remaining/limit/reset
+                               so the token becomes available again (remaining ?? 1 > 0)
+```
+
+## Validation Flow
+
+### `ensureTokensValidated` (normal requests)
+
+Called once per request cycle (idempotent via `_validatePromise`):
+
+1. Race all PAT validations and App token bootstrap in parallel — resolve as soon as any token is available
+2. If no token available after race, falls back to `revalidateGHTokens()`
+
+### `ensureAllTokensValidated` (status page only)
+
+1. Validate all PAT tokens in parallel (each calls GET /meta — costs 1 API request)
+2. Bootstrap App tokens (JWT -> list installations -> create installation tokens)
+3. Revalidate any stale tokens
+
+## Revalidation (`revalidateGHTokens`)
+
+- Concurrent callers share one in-flight promise (coalesced)
+- Only revalidates tokens where `isStale()` is true
+- Also calls `ensureAppToken()` to refresh app tokens if needed
+- Short-circuits if no tokens are stale AND at least one token is available
+
+## Cached Fetch (`ghFetch`)
+
+- Wraps `ofetch` with GitHub auth headers
+- Uses `defineCachedFunction` (6h maxAge, 12h staleMaxAge, no SWR)
+- On every response, updates the token's rate limit via `onResponse`
+- If no token available, attempts revalidation once, then throws 403
+- Cache validation rejects empty arrays and zero-count results
+
+## Helper Endpoints
+
+- `ghRepo(repo)` — GET /repos/:repo (cached)
+- `ghRepoContributors(repo)` — GET /repos/:repo/contributors (cached)
+- `ghRepoFiles(repo, ref)` — GET /repos/:repo/git/trees/:ref?recursive=1 (cached)
+- `ghMarkdown(md, repo, id)` — POST /markdown (cached, keyed by repo/id)
+
+## Status Page (`routes/_status.ts`)
+
+HTML dashboard showing per-token and aggregate rate limit usage with color-coded bars.
+
+## Key Design Decisions
+
+- `valid !== false` (not `valid === true`) in `clearExpiredLimits` — allows clearing rate limits for never-validated tokens that have stale rate limit state
+- `remaining ?? 1` in `available` getter — treats never-checked tokens as available (optimistic until proven otherwise)
+- App token refresh is self-scheduling via `setTimeout`, not driven by requests
+- Transport errors in `validate()` preserve last-known state (no flip to invalid)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,3 +22,4 @@ jobs:
       - run: pnpm lint
       - run: pnpm typecheck
       - run: pnpm build
+      - run: pnpm vitest run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 This project is based on [Nitro](https://nitro.build) v3, [h3](https://h3.dev/), [Vite](https://vite.dev/) and [rolldown](https://rolldown.rs/).
 
+## Deep Dives
+
+- @.agents/GH_API.md — GitHub API token system, rate-limit tracking, cached fetch layer
+
 ## Project Structure
 
 `routes/` contains route handlers. `utils/` has shared utilities (`github.ts` for GitHub API, `markdown.ts` for markdown processing). `types/` for shared types. `public/` holds static assets. Config: `nitro.config.ts` (storage, routeRules, openAPI), `tsconfig.json` (extends `nitro/tsconfig`, `~/*` path alias).

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "oxlint": "^1.56.0",
     "std-env": "^4.0.0",
     "typescript": "^5.9.3",
-    "ufo": "^1.6.3"
+    "ufo": "^1.6.3",
+    "vitest": "^4.1.0"
   },
   "packageManager": "pnpm@10.32.1"
 }

--- a/package.json
+++ b/package.json
@@ -9,13 +9,14 @@
     "preview": "nitro preview",
     "lint": "oxlint . && oxfmt --check .",
     "fmt": "oxlint --fix . && oxfmt .",
-    "test": "pnpm lint && pnpm typecheck",
+    "test": "pnpm lint && pnpm typecheck && vitest run --coverage",
     "typecheck": "tsgo --noEmit"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
     "@typescript/native-preview": "^7.0.0-dev.20260318.1",
     "@upstash/redis": "^1.37.0",
+    "@vitest/coverage-v8": "4.1.0",
     "defu": "^6.1.4",
     "nitro": "^3.0.260311-beta",
     "openapi-renderer": "^0.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 6.1.4
       nitro:
         specifier: ^3.0.260311-beta
-        version: 3.0.260311-beta(@upstash/redis@1.37.0)
+        version: 3.0.260311-beta(@upstash/redis@1.37.0)(vite@8.0.1(@types/node@25.5.0))
       openapi-renderer:
         specifier: ^0.1.1
         version: 0.1.1
@@ -41,6 +41,9 @@ importers:
       ufo:
         specifier: ^1.6.3
         version: 1.6.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@25.5.0)(vite@8.0.1(@types/node@25.5.0))
 
 packages:
 
@@ -53,11 +56,17 @@ packages:
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
   '@oxc-project/types@0.115.0':
     resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
+
+  '@oxc-project/types@0.120.0':
+    resolution: {integrity: sha512-k1YNu55DuvAip/MGE1FTsIuU3FUCn6v/ujG9V7Nq5Df/kX2CWb13hhwD0lmJGMGqE+bE1MXvv9SZVnMzEXlWcg==}
 
   '@oxfmt/binding-android-arm-eabi@0.41.0':
     resolution: {integrity: sha512-REfrqeMKGkfMP+m/ScX4f5jJBSmVNYcpoDF8vP8f8eYPDuPGZmzp56NIUsYmx3h7f6NzC6cE3gqh8GDWrJHCKw==}
@@ -303,16 +312,34 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.10':
+    resolution: {integrity: sha512-jOHxwXhxmFKuXztiu1ORieJeTbx5vrTkcOkkkn2d35726+iwhrY1w/+nYY/AGgF12thg33qC3R1LMBF5tHTZHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-android-arm64@1.0.0-rc.9':
     resolution: {integrity: sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.10':
+    resolution: {integrity: sha512-gED05Teg/vtTZbIJBc4VNMAxAFDUPkuO/rAIyyxZjTj1a1/s6z5TII/5yMGZ0uLRCifEtwUQn8OlYzuYc0m70w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
     resolution: {integrity: sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.10':
+    resolution: {integrity: sha512-rI15NcM1mA48lqrIxVkHfAqcyFLcQwyXWThy+BQ5+mkKKPvSO26ir+ZDp36AgYoYVkqvMcdS8zOE6SeBsR9e8A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.9':
@@ -321,17 +348,36 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.10':
+    resolution: {integrity: sha512-XZRXHdTa+4ME1MuDVp021+doQ+z6Ei4CCFmNc5/sKbqb8YmkiJdj8QKlV3rCI0AJtAeSB5n0WGPuJWNL9p/L2w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
     resolution: {integrity: sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.10':
+    resolution: {integrity: sha512-R0SQMRluISSLzFE20sPWYHVmJdDQnRyc/FzSCN72BqQmh2SOZUFG+N3/vBZpR4C6WpEUVYJLrYUXaj43sJsNLA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
     resolution: {integrity: sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.10':
+    resolution: {integrity: sha512-Y1reMrV/o+cwpduYhJuOE3OMKx32RMYCidf14y+HssARRmhDuWXJ4yVguDg2R/8SyyGNo+auzz64LnPK9Hq6jg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==}
@@ -340,6 +386,13 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
+    resolution: {integrity: sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -347,10 +400,24 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10':
+    resolution: {integrity: sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10':
+    resolution: {integrity: sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
@@ -361,12 +428,26 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
+    resolution: {integrity: sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
+    resolution: {integrity: sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
@@ -375,21 +456,44 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.10':
+    resolution: {integrity: sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
     resolution: {integrity: sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.10':
+    resolution: {integrity: sha512-Ugv9o7qYJudqQO5Y5y2N2SOo6S4WiqiNOpuQyoPInnhVzCY+wi/GHltcLHypG9DEUYMB0iTB/huJrpadiAcNcA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
     resolution: {integrity: sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.10':
+    resolution: {integrity: sha512-7UODQb4fQUNT/vmgDZBl3XOBAIOutP5R3O/rkxg0aLfEGQ4opbCgU5vOw/scPe4xOqBwL9fw7/RP1vAMZ6QlAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
     resolution: {integrity: sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
+    resolution: {integrity: sha512-PYxKHMVHOb5NJuDL53vBUl1VwUjymDcYI6rzpIni0C9+9mTiJedvUxSk7/RPp7OOAm3v+EjgMu9bIy3N6b408w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [win32]
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
@@ -398,11 +502,26 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@rolldown/pluginutils@1.0.0-rc.10':
+    resolution: {integrity: sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==}
+
   '@rolldown/pluginutils@1.0.0-rc.9':
     resolution: {integrity: sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
@@ -449,9 +568,49 @@ packages:
   '@upstash/redis@1.37.0':
     resolution: {integrity: sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==}
 
+  '@vitest/expect@4.1.0':
+    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+
+  '@vitest/mocker@4.1.0':
+    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.0':
+    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
+
+  '@vitest/runner@4.1.0':
+    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
+
+  '@vitest/snapshot@4.1.0':
+    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
+
+  '@vitest/spy@4.1.0':
+    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+
+  '@vitest/utils@4.1.0':
+    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   crossws@0.4.4:
     resolution: {integrity: sha512-w6c4OdpRNnudVmcgr7brb/+/HmYjMQvYToO/oTrprTwxRUiom3LYWU1PMWuD006okbUWpII1Ea9/+kwpUfmyRg==}
@@ -487,6 +646,10 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   env-runner@0.1.6:
     resolution: {integrity: sha512-fSb7X1zdda8k6611a6/SdSQpDe7a/bqMz2UWdbHjk9YWzpUR4/fn9YtE/hqgGQ2nhvVN0zUtcL1SRMKwIsDbAA==}
     hasBin: true
@@ -495,6 +658,30 @@ packages:
     peerDependenciesMeta:
       miniflare:
         optional: true
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   h3@2.0.1-rc.16:
     resolution: {integrity: sha512-h+pjvyujdo9way8qj6FUbhaQcHlR8FEq65EhTX9ViT5pK8aLj68uFl4hBkF+hsTJAH+H1END2Yv6hTIsabGfag==}
@@ -511,6 +698,88 @@ packages:
 
   httpxy@0.3.1:
     resolution: {integrity: sha512-XjG/CEoofEisMrnFr0D6U6xOZ4mRfnwcYQ9qvvnT4lvnX8BoeA3x3WofB75D+vZwpaobFVkBIHrZzoK40w8XSw==}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   nf3@0.3.11:
     resolution: {integrity: sha512-ObKp/SA3f1g1f/OMeDlRWaZmqGgk7A0NnDIbeO7c/MV4r/quMlpP/BsqMGuTi3lUlXbC1On8YH7ICM2u2bIAOw==}
@@ -542,6 +811,9 @@ packages:
         optional: true
       zephyr-agent:
         optional: true
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   ocache@0.1.2:
     resolution: {integrity: sha512-lI34wjM7cahEdrq2I5obbF7MEdE97vULf6vNj6ZCzwEadzyXO1w7QOl2qzzG4IL8cyO7wDtXPj9CqW/aG3mn7g==}
@@ -581,6 +853,22 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rolldown@1.0.0-rc.10:
+    resolution: {integrity: sha512-q7j6vvarRFmKpgJUT8HCAUljkgzEp4LAhPlJUvQhA5LA1SUL36s5QCysMutErzL3EbNOZOkoziSx9iZC4FddKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rolldown@1.0.0-rc.9:
     resolution: {integrity: sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -589,17 +877,42 @@ packages:
   rou3@0.8.1:
     resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   srvx@0.11.12:
     resolution: {integrity: sha512-AQfrGqntqVPXgP03pvBDN1KyevHC+KmYVqb8vVf4N+aomQqdhaZxjvoVp+AOm4u6x+GgNQY3MVzAUIn+TqwkOA==}
     engines: {node: '>=20.16.0'}
     hasBin: true
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.4:
+    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
 
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -695,6 +1008,89 @@ packages:
       uploadthing:
         optional: true
 
+  vite@8.0.1:
+    resolution: {integrity: sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.0:
+    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.0
+      '@vitest/browser-preview': 4.1.0
+      '@vitest/browser-webdriverio': 4.1.0
+      '@vitest/ui': 4.1.0
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
 snapshots:
 
   '@emnapi/core@1.9.0':
@@ -713,6 +1109,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
       '@emnapi/core': 1.9.0
@@ -721,6 +1119,8 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.115.0': {}
+
+  '@oxc-project/types@0.120.0': {}
 
   '@oxfmt/binding-android-arm-eabi@0.41.0':
     optional: true
@@ -836,40 +1236,81 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.56.0':
     optional: true
 
+  '@rolldown/binding-android-arm64@1.0.0-rc.10':
+    optional: true
+
   '@rolldown/binding-android-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.10':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.0.0-rc.10':
+    optional: true
+
   '@rolldown/binding-darwin-x64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.10':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.10':
+    optional: true
+
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.10':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
+    optional: true
+
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
     optional: true
 
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10':
+    optional: true
+
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
+    optional: true
+
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
     optional: true
 
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.10':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.10':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
@@ -877,18 +1318,37 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.10':
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.10':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
     optional: true
 
+  '@rolldown/pluginutils@1.0.0-rc.10': {}
+
   '@rolldown/pluginutils@1.0.0-rc.9': {}
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.8': {}
 
   '@types/node@25.5.0':
     dependencies:
@@ -929,7 +1389,54 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
+  '@vitest/expect@4.1.0':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.0(vite@8.0.1(@types/node@25.5.0))':
+    dependencies:
+      '@vitest/spy': 4.1.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.1(@types/node@25.5.0)
+
+  '@vitest/pretty-format@4.1.0':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.0':
+    dependencies:
+      '@vitest/utils': 4.1.0
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/utils': 4.1.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.0': {}
+
+  '@vitest/utils@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  assertion-error@2.0.1: {}
+
+  chai@6.2.2: {}
+
   consola@3.4.2: {}
+
+  convert-source-map@2.0.0: {}
 
   crossws@0.4.4(srvx@0.11.12):
     optionalDependencies:
@@ -939,11 +1446,28 @@ snapshots:
 
   defu@6.1.4: {}
 
+  detect-libc@2.1.2: {}
+
   env-runner@0.1.6:
     dependencies:
       crossws: 0.4.4(srvx@0.11.12)
       httpxy: 0.3.1
       srvx: 0.11.12
+
+  es-module-lexer@2.0.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fsevents@2.3.3:
+    optional: true
 
   h3@2.0.1-rc.16(crossws@0.4.4(srvx@0.11.12)):
     dependencies:
@@ -956,9 +1480,64 @@ snapshots:
 
   httpxy@0.3.1: {}
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  nanoid@3.3.11: {}
+
   nf3@0.3.11: {}
 
-  nitro@3.0.260311-beta(@upstash/redis@1.37.0):
+  nitro@3.0.260311-beta(@upstash/redis@1.37.0)(vite@8.0.1(@types/node@25.5.0)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.4(srvx@0.11.12)
@@ -974,6 +1553,8 @@ snapshots:
       srvx: 0.11.12
       unenv: 2.0.0-rc.24
       unstorage: 2.0.0-alpha.6(@upstash/redis@1.37.0)(db0@0.3.4)(ofetch@2.0.0-alpha.3)
+    optionalDependencies:
+      vite: 8.0.1(@types/node@25.5.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -1003,6 +1584,8 @@ snapshots:
       - mysql2
       - sqlite3
       - uploadthing
+
+  obug@2.1.1: {}
 
   ocache@0.1.2:
     dependencies:
@@ -1062,6 +1645,37 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  postcss@8.5.8:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rolldown@1.0.0-rc.10:
+    dependencies:
+      '@oxc-project/types': 0.120.0
+      '@rolldown/pluginutils': 1.0.0-rc.10
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.10
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.10
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.10
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.10
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.10
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.10
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.10
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.10
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.10
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.10
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.10
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.10
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.10
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.10
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.10
+
   rolldown@1.0.0-rc.9:
     dependencies:
       '@oxc-project/types': 0.115.0
@@ -1085,11 +1699,28 @@ snapshots:
 
   rou3@0.8.1: {}
 
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
   srvx@0.11.12: {}
+
+  stackback@0.0.2: {}
 
   std-env@4.0.0: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.4: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
   tinypool@2.1.0: {}
+
+  tinyrainbow@3.1.0: {}
 
   tslib@2.8.1:
     optional: true
@@ -1111,3 +1742,46 @@ snapshots:
       '@upstash/redis': 1.37.0
       db0: 0.3.4
       ofetch: 2.0.0-alpha.3
+
+  vite@8.0.1(@types/node@25.5.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.10
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.5.0
+      fsevents: 2.3.3
+
+  vitest@4.1.0(@types/node@25.5.0)(vite@8.0.1(@types/node@25.5.0)):
+    dependencies:
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@8.0.1(@types/node@25.5.0))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.1(@types/node@25.5.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.5.0
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@upstash/redis':
         specifier: ^1.37.0
         version: 1.37.0
+      '@vitest/coverage-v8':
+        specifier: 4.1.0
+        version: 4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@8.0.1(@types/node@25.5.0)))
       defu:
         specifier: ^6.1.4
         version: 6.1.4
@@ -47,6 +50,27 @@ importers:
 
 packages:
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
 
@@ -56,8 +80,15 @@ packages:
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
@@ -568,6 +599,15 @@ packages:
   '@upstash/redis@1.37.0':
     resolution: {integrity: sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==}
 
+  '@vitest/coverage-v8@4.1.0':
+    resolution: {integrity: sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==}
+    peerDependencies:
+      '@vitest/browser': 4.1.0
+      vitest: 4.1.0
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@4.1.0':
     resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
 
@@ -600,6 +640,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -693,11 +736,33 @@ packages:
       crossws:
         optional: true
 
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
   hookable@6.1.0:
     resolution: {integrity: sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw==}
 
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   httpxy@0.3.1:
     resolution: {integrity: sha512-XjG/CEoofEisMrnFr0D6U6xOZ4mRfnwcYQ9qvvnT4lvnX8BoeA3x3WofB75D+vZwpaobFVkBIHrZzoK40w8XSw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -775,6 +840,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -877,6 +949,11 @@ packages:
   rou3@0.8.1:
     resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -894,6 +971,10 @@ packages:
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1093,6 +1174,21 @@ packages:
 
 snapshots:
 
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
+
   '@emnapi/core@1.9.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.0
@@ -1109,7 +1205,14 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
@@ -1389,6 +1492,20 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@types/node@25.5.0)(vite@8.0.1(@types/node@25.5.0)))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.0
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.0(@types/node@25.5.0)(vite@8.0.1(@types/node@25.5.0))
+
   '@vitest/expect@4.1.0':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -1431,6 +1548,12 @@ snapshots:
       tinyrainbow: 3.1.0
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   chai@6.2.2: {}
 
@@ -1476,9 +1599,28 @@ snapshots:
     optionalDependencies:
       crossws: 0.4.4(srvx@0.11.12)
 
+  has-flag@4.0.0: {}
+
   hookable@6.1.0: {}
 
+  html-escaper@2.0.2: {}
+
   httpxy@0.3.1: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  js-tokens@10.0.0: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -1532,6 +1674,16 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   nanoid@3.3.11: {}
 
@@ -1699,6 +1851,8 @@ snapshots:
 
   rou3@0.8.1: {}
 
+  semver@7.7.4: {}
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -1708,6 +1862,10 @@ snapshots:
   stackback@0.0.2: {}
 
   std-env@4.0.0: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   tinybench@2.9.0: {}
 

--- a/routes/_status.ts
+++ b/routes/_status.ts
@@ -1,6 +1,6 @@
 import { defineRouteMeta, defineHandler } from "nitro";
 import { html } from "nitro/h3";
-import { ghTokens, ensureTokensValidated, formatDuration } from "~/utils/github";
+import { ghTokens, ensureAllTokensValidated, formatDuration } from "~/utils/github";
 
 defineRouteMeta({
   openAPI: {
@@ -9,7 +9,7 @@ defineRouteMeta({
 });
 
 export default defineHandler(async () => {
-  await ensureTokensValidated();
+  await ensureAllTokensValidated();
 
   const tokens = ghTokens.map((t, i) => {
     const remaining = t.remaining ?? 0;

--- a/routes/_status.ts
+++ b/routes/_status.ts
@@ -1,6 +1,6 @@
 import { defineRouteMeta, defineHandler } from "nitro";
 import { html } from "nitro/h3";
-import { ghTokens, ensureAllTokensValidated, formatDuration } from "~/utils/github";
+import { ghTokens, ensureAllTokensValidated, formatDuration } from "~/utils/github_token";
 
 defineRouteMeta({
   openAPI: {

--- a/routes/users/find/[query].ts
+++ b/routes/users/find/[query].ts
@@ -28,9 +28,7 @@ export default defineHandler(async (event) => {
     query = anonMatch[1]!;
   }
 
-  const res = await ghFetch("/search/users", {
-    params: { q: query },
-  });
+  const res = await ghFetch(`/search/users?q=${encodeURIComponent(query)}`);
 
   if (res.items.length === 0) {
     throw new HTTPError({

--- a/test/github_token.test.ts
+++ b/test/github_token.test.ts
@@ -9,6 +9,7 @@ import {
   ensureTokensValidated,
   ensureAllTokensValidated,
   revalidateGHTokens,
+  ensureAppToken,
 } from "~/utils/github_token";
 
 function mockResponse(status: number, headers: Record<string, string> = {}): Response {
@@ -497,6 +498,7 @@ describe("ensureTokensValidated", () => {
   beforeEach(() => {
     fetchSpy = vi.spyOn(globalThis, "fetch");
     ghTokens.length = 0;
+    ensureTokensValidated.reset();
   });
 
   afterEach(() => {
@@ -542,6 +544,8 @@ describe("ensureAllTokensValidated", () => {
   beforeEach(() => {
     fetchSpy = vi.spyOn(globalThis, "fetch");
     ghTokens.length = 0;
+    ensureAllTokensValidated.reset();
+    ensureAppToken.reset();
   });
 
   afterEach(() => {

--- a/test/github_token.test.ts
+++ b/test/github_token.test.ts
@@ -1,10 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { GHToken } from "~/utils/github_token";
 
-function mockResponse(
-  status: number,
-  headers: Record<string, string> = {},
-): Response {
+function mockResponse(status: number, headers: Record<string, string> = {}): Response {
   return new Response(null, { status, headers });
 }
 
@@ -25,9 +22,7 @@ describe("GHToken", () => {
     it("parses rate limit headers from successful response", () => {
       const token = new GHToken("test-token");
       const resetEpoch = Math.floor(Date.now() / 1000) + 3600;
-      token.updateStatus(
-        mockResponse(200, rateLimitHeaders(4999, 5000, resetEpoch)),
-      );
+      token.updateStatus(mockResponse(200, rateLimitHeaders(4999, 5000, resetEpoch)));
 
       expect(token.valid).toBe(true);
       expect(token.remaining).toBe(4999);
@@ -46,9 +41,7 @@ describe("GHToken", () => {
     it("marks token valid on 403 (rate limited, not auth failure)", () => {
       const token = new GHToken("test-token");
       const resetEpoch = Math.floor(Date.now() / 1000) + 60;
-      token.updateStatus(
-        mockResponse(403, rateLimitHeaders(0, 5000, resetEpoch)),
-      );
+      token.updateStatus(mockResponse(403, rateLimitHeaders(0, 5000, resetEpoch)));
 
       expect(token.valid).toBe(true);
       expect(token.remaining).toBe(0);
@@ -94,9 +87,7 @@ describe("GHToken", () => {
     });
 
     it("marks token invalid on 401 response", async () => {
-      fetchSpy.mockResolvedValueOnce(
-        mockResponse(401, rateLimitHeaders(0, 0)),
-      );
+      fetchSpy.mockResolvedValueOnce(mockResponse(401, rateLimitHeaders(0, 0)));
 
       const token = new GHToken("bad-token");
       await token.validate();
@@ -119,9 +110,7 @@ describe("GHToken", () => {
     });
 
     it("sends authorization header", async () => {
-      fetchSpy.mockResolvedValueOnce(
-        mockResponse(200, rateLimitHeaders(5000, 5000)),
-      );
+      fetchSpy.mockResolvedValueOnce(mockResponse(200, rateLimitHeaders(5000, 5000)));
 
       const token = new GHToken("ghp_secret123");
       await token.validate();

--- a/test/github_token.test.ts
+++ b/test/github_token.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GHToken } from "~/utils/github_token";
+
+function mockResponse(
+  status: number,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(null, { status, headers });
+}
+
+function rateLimitHeaders(
+  remaining: number,
+  limit: number,
+  resetEpoch?: number,
+): Record<string, string> {
+  return {
+    "x-ratelimit-remaining": String(remaining),
+    "x-ratelimit-limit": String(limit),
+    ...(resetEpoch ? { "x-ratelimit-reset": String(resetEpoch) } : {}),
+  };
+}
+
+describe("GHToken", () => {
+  describe("updateStatus", () => {
+    it("parses rate limit headers from successful response", () => {
+      const token = new GHToken("test-token");
+      const resetEpoch = Math.floor(Date.now() / 1000) + 3600;
+      token.updateStatus(
+        mockResponse(200, rateLimitHeaders(4999, 5000, resetEpoch)),
+      );
+
+      expect(token.valid).toBe(true);
+      expect(token.remaining).toBe(4999);
+      expect(token.limit).toBe(5000);
+      expect(token.reset).toBe(resetEpoch * 1000);
+    });
+
+    it("marks token invalid on 401", () => {
+      const token = new GHToken("bad-token");
+      token.updateStatus(mockResponse(401, rateLimitHeaders(0, 0)));
+
+      expect(token.valid).toBe(false);
+      expect(token.remaining).toBe(0);
+    });
+
+    it("marks token valid on 403 (rate limited, not auth failure)", () => {
+      const token = new GHToken("test-token");
+      const resetEpoch = Math.floor(Date.now() / 1000) + 60;
+      token.updateStatus(
+        mockResponse(403, rateLimitHeaders(0, 5000, resetEpoch)),
+      );
+
+      expect(token.valid).toBe(true);
+      expect(token.remaining).toBe(0);
+    });
+
+    it("handles missing reset header", () => {
+      const token = new GHToken("test-token");
+      token.updateStatus(mockResponse(200, rateLimitHeaders(100, 5000)));
+
+      expect(token.reset).toBeUndefined();
+    });
+  });
+
+  describe("validate", () => {
+    let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      fetchSpy = vi.spyOn(globalThis, "fetch");
+    });
+
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
+
+    it("updates status from /meta response", async () => {
+      const resetEpoch = Math.floor(Date.now() / 1000) + 3600;
+      fetchSpy.mockResolvedValueOnce(
+        mockResponse(200, {
+          ...rateLimitHeaders(4500, 5000, resetEpoch),
+          "x-ratelimit-resource": "core",
+        }),
+      );
+
+      const token = new GHToken("test-token");
+      await token.validate();
+
+      expect(token.valid).toBe(true);
+      expect(token.remaining).toBe(4500);
+      expect(token.limit).toBe(5000);
+      expect(token._lastValidated).toBeTypeOf("number");
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      expect(fetchSpy.mock.calls[0]![0]).toMatch(/api\.github\.com\/meta/);
+    });
+
+    it("marks token invalid on 401 response", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        mockResponse(401, rateLimitHeaders(0, 0)),
+      );
+
+      const token = new GHToken("bad-token");
+      await token.validate();
+
+      expect(token.valid).toBe(false);
+      expect(token._lastValidated).toBeTypeOf("number");
+    });
+
+    it("preserves state on transport error", async () => {
+      fetchSpy.mockRejectedValue(new TypeError("fetch failed"));
+
+      const token = new GHToken("test-token");
+      token.valid = true;
+      token.remaining = 1000;
+      await token.validate();
+
+      expect(token.valid).toBe(true);
+      expect(token.remaining).toBe(1000);
+      expect(token._lastValidated).toBeUndefined();
+    });
+
+    it("sends authorization header", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        mockResponse(200, rateLimitHeaders(5000, 5000)),
+      );
+
+      const token = new GHToken("ghp_secret123");
+      await token.validate();
+
+      const [, init] = fetchSpy.mock.calls[0]!;
+      const headers = new Headers((init as RequestInit)?.headers);
+      expect(headers.get("Authorization")).toBe("token ghp_secret123");
+    });
+  });
+
+  describe("isStale", () => {
+    it("returns true when never validated", () => {
+      const token = new GHToken("test-token");
+      expect(token.isStale()).toBe(true);
+    });
+
+    it("returns false when recently validated", () => {
+      const token = new GHToken("test-token");
+      token._lastValidated = Date.now();
+      expect(token.isStale()).toBe(false);
+    });
+
+    it("returns true when validated more than 1 minute ago", () => {
+      const token = new GHToken("test-token");
+      token._lastValidated = Date.now() - 61_000;
+      expect(token.isStale()).toBe(true);
+    });
+
+    it("returns false when rate limit reset is pending", () => {
+      const token = new GHToken("test-token");
+      token._lastValidated = Date.now() - 120_000; // stale by time
+      token.reset = Date.now() + 60_000; // but reset is in the future
+      expect(token.isStale()).toBe(false);
+    });
+
+    it("returns true when rate limit reset has passed", () => {
+      const token = new GHToken("test-token");
+      token._lastValidated = Date.now() - 120_000;
+      token.reset = Date.now() - 1000; // reset is in the past
+      expect(token.isStale()).toBe(true);
+    });
+  });
+
+  describe("clearExpiredLimits", () => {
+    it("clears limits when reset has passed", () => {
+      const token = new GHToken("test-token");
+      token.valid = true;
+      token.remaining = 0;
+      token.limit = 5000;
+      token.reset = Date.now() - 1000;
+
+      token.clearExpiredLimits();
+
+      expect(token.remaining).toBeUndefined();
+      expect(token.limit).toBeUndefined();
+      expect(token.reset).toBeUndefined();
+    });
+
+    it("does not clear when reset is still in the future", () => {
+      const token = new GHToken("test-token");
+      token.valid = true;
+      token.remaining = 0;
+      token.limit = 5000;
+      token.reset = Date.now() + 60_000;
+
+      token.clearExpiredLimits();
+
+      expect(token.remaining).toBe(0);
+      expect(token.limit).toBe(5000);
+      expect(token.reset).toBeDefined();
+    });
+
+    it("does not clear when remaining > 0", () => {
+      const token = new GHToken("test-token");
+      token.valid = true;
+      token.remaining = 100;
+      token.limit = 5000;
+      token.reset = Date.now() - 1000;
+
+      token.clearExpiredLimits();
+
+      expect(token.remaining).toBe(100);
+    });
+
+    it("does not clear for invalid tokens", () => {
+      const token = new GHToken("test-token");
+      token.valid = false;
+      token.remaining = 0;
+      token.limit = 5000;
+      token.reset = Date.now() - 1000;
+
+      token.clearExpiredLimits();
+
+      expect(token.remaining).toBe(0);
+    });
+
+    it("clears when valid is undefined (never validated)", () => {
+      const token = new GHToken("test-token");
+      // valid is undefined
+      token.remaining = 0;
+      token.limit = 5000;
+      token.reset = Date.now() - 1000;
+
+      token.clearExpiredLimits();
+
+      expect(token.remaining).toBeUndefined();
+      expect(token.limit).toBeUndefined();
+      expect(token.reset).toBeUndefined();
+    });
+  });
+
+  describe("available", () => {
+    it("returns true for valid token with remaining requests", () => {
+      const token = new GHToken("test-token");
+      token.valid = true;
+      token.remaining = 100;
+      expect(token.available).toBe(true);
+    });
+
+    it("returns false for invalid token", () => {
+      const token = new GHToken("test-token");
+      token.valid = false;
+      token.remaining = 100;
+      expect(token.available).toBe(false);
+    });
+
+    it("returns false for exhausted token", () => {
+      const token = new GHToken("test-token");
+      token.valid = true;
+      token.remaining = 0;
+      expect(token.available).toBe(false);
+    });
+
+    it("returns true for unvalidated token (valid=undefined treated as falsy)", () => {
+      const token = new GHToken("test-token");
+      // valid is undefined, remaining is undefined
+      expect(token.available).toBeFalsy();
+    });
+
+    it("returns true when remaining is undefined (fresh valid token)", () => {
+      const token = new GHToken("test-token");
+      token.valid = true;
+      // remaining undefined → defaults to 1
+      expect(token.available).toBe(true);
+    });
+  });
+});

--- a/test/github_token.test.ts
+++ b/test/github_token.test.ts
@@ -13,6 +13,8 @@ import {
   acquireGHToken,
 } from "~/utils/github_token";
 
+// --- Test helpers ---
+
 function mockResponse(status: number, headers: Record<string, string> = {}): Response {
   return new Response(null, { status, headers });
 }
@@ -28,6 +30,71 @@ function rateLimitHeaders(
     ...(resetEpoch ? { "x-ratelimit-reset": String(resetEpoch) } : {}),
   };
 }
+
+/** Generates a PEM key pair for App JWT tests. Cached after first call. */
+let _cachedKeyPair: { pem: string; keyPair: CryptoKeyPair } | undefined;
+async function getTestKeyPair() {
+  if (!_cachedKeyPair) {
+    const keyPair = await crypto.subtle.generateKey(
+      {
+        name: "RSASSA-PKCS1-v1_5",
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      true,
+      ["sign", "verify"],
+    );
+    const pkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+    const pem = `-----BEGIN PRIVATE KEY-----\n${btoa(String.fromCharCode(...new Uint8Array(pkcs8)))}\n-----END PRIVATE KEY-----`;
+    _cachedKeyPair = { pem, keyPair };
+  }
+  return _cachedKeyPair;
+}
+
+/** Creates a fetch mock that routes GitHub App API calls. */
+function mockAppFetch(
+  fetchSpy: ReturnType<typeof vi.spyOn>,
+  opts: {
+    installations?: { id: number }[];
+    installationsStatus?: number;
+    accessToken?: { token: string; expires_at: string };
+    accessTokenStatus?: number;
+  } = {},
+) {
+  const {
+    installations = [{ id: 42 }],
+    installationsStatus = 200,
+    accessToken = {
+      token: "ghs_installtoken123456",
+      expires_at: new Date(Date.now() + 3600_000).toISOString(),
+    },
+    accessTokenStatus = 200,
+  } = opts;
+
+  fetchSpy.mockImplementation(async (url: string | URL | Request) => {
+    const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+    if (urlStr.includes("/app/installations") && !urlStr.includes("/access_tokens")) {
+      return new Response(JSON.stringify(installations), {
+        status: installationsStatus,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (urlStr.includes("/access_tokens")) {
+      if (accessTokenStatus !== 200) {
+        return new Response(null, { status: accessTokenStatus });
+      }
+      return new Response(JSON.stringify(accessToken), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    // validate call (/meta)
+    return mockResponse(200, rateLimitHeaders(4500, 5000));
+  });
+}
+
+// --- GHToken class ---
 
 describe("GHToken", () => {
   describe("updateStatus", () => {
@@ -45,16 +112,13 @@ describe("GHToken", () => {
     it("marks token invalid on 401", () => {
       const token = new GHToken("bad-token");
       token.updateStatus(mockResponse(401, rateLimitHeaders(0, 0)));
-
       expect(token.valid).toBe(false);
       expect(token.remaining).toBe(0);
     });
 
     it("marks token valid on 403 (rate limited, not auth failure)", () => {
       const token = new GHToken("test-token");
-      const resetEpoch = Math.floor(Date.now() / 1000) + 60;
-      token.updateStatus(mockResponse(403, rateLimitHeaders(0, 5000, resetEpoch)));
-
+      token.updateStatus(mockResponse(403, rateLimitHeaders(0, 5000)));
       expect(token.valid).toBe(true);
       expect(token.remaining).toBe(0);
     });
@@ -62,21 +126,14 @@ describe("GHToken", () => {
     it("handles missing reset header", () => {
       const token = new GHToken("test-token");
       token.updateStatus(mockResponse(200, rateLimitHeaders(100, 5000)));
-
       expect(token.reset).toBeUndefined();
     });
   });
 
   describe("validate", () => {
     let fetchSpy: ReturnType<typeof vi.spyOn>;
-
-    beforeEach(() => {
-      fetchSpy = vi.spyOn(globalThis, "fetch");
-    });
-
-    afterEach(() => {
-      fetchSpy.mockRestore();
-    });
+    beforeEach(() => { fetchSpy = vi.spyOn(globalThis, "fetch"); });
+    afterEach(() => { fetchSpy.mockRestore(); });
 
     it("updates status from /meta response", async () => {
       const resetEpoch = Math.floor(Date.now() / 1000) + 3600;
@@ -100,22 +157,18 @@ describe("GHToken", () => {
 
     it("marks token invalid on 401 response", async () => {
       fetchSpy.mockResolvedValueOnce(mockResponse(401, rateLimitHeaders(0, 0)));
-
       const token = new GHToken("bad-token");
       await token.validate();
-
       expect(token.valid).toBe(false);
       expect(token._lastValidated).toBeTypeOf("number");
     });
 
     it("preserves state on transport error", async () => {
       fetchSpy.mockRejectedValue(new TypeError("fetch failed"));
-
       const token = new GHToken("test-token");
       token.valid = true;
       token.remaining = 1000;
       await token.validate();
-
       expect(token.valid).toBe(true);
       expect(token.remaining).toBe(1000);
       expect(token._lastValidated).toBeUndefined();
@@ -123,10 +176,8 @@ describe("GHToken", () => {
 
     it("sends authorization header", async () => {
       fetchSpy.mockResolvedValueOnce(mockResponse(200, rateLimitHeaders(5000, 5000)));
-
       const token = new GHToken("ghp_secret123");
       await token.validate();
-
       const [, init] = fetchSpy.mock.calls[0]!;
       const headers = new Headers((init as RequestInit)?.headers);
       expect(headers.get("Authorization")).toBe("token ghp_secret123");
@@ -134,139 +185,70 @@ describe("GHToken", () => {
   });
 
   describe("isStale", () => {
-    it("returns true when never validated", () => {
-      const token = new GHToken("test-token");
-      expect(token.isStale()).toBe(true);
-    });
+    const now = 1_000_000;
 
-    it("returns false when recently validated", () => {
-      const token = new GHToken("test-token");
-      token._lastValidated = Date.now();
-      expect(token.isStale()).toBe(false);
-    });
-
-    it("returns true when validated more than 1 minute ago", () => {
-      const token = new GHToken("test-token");
-      token._lastValidated = Date.now() - 61_000;
-      expect(token.isStale()).toBe(true);
-    });
-
-    it("returns false when rate limit reset is pending", () => {
-      const token = new GHToken("test-token");
-      token._lastValidated = Date.now() - 120_000; // stale by time
-      token.reset = Date.now() + 60_000; // but reset is in the future
-      expect(token.isStale()).toBe(false);
-    });
-
-    it("returns true when rate limit reset has passed", () => {
-      const token = new GHToken("test-token");
-      token._lastValidated = Date.now() - 120_000;
-      token.reset = Date.now() - 1000; // reset is in the past
-      expect(token.isStale()).toBe(true);
+    it.each([
+      { desc: "never validated", lastValidated: undefined, reset: undefined, expected: true },
+      { desc: "recently validated", lastValidated: now - 1000, reset: undefined, expected: false },
+      { desc: "validated >1min ago", lastValidated: now - 61_000, reset: undefined, expected: true },
+      { desc: "stale but reset pending", lastValidated: now - 120_000, reset: now + 60_000, expected: false },
+      { desc: "stale and reset passed", lastValidated: now - 120_000, reset: now - 1000, expected: true },
+    ])("$desc → $expected", ({ lastValidated, reset, expected }) => {
+      const token = new GHToken("t");
+      token._lastValidated = lastValidated;
+      if (reset !== undefined) token.reset = reset;
+      expect(token.isStale(now)).toBe(expected);
     });
   });
 
   describe("clearExpiredLimits", () => {
-    it("clears limits when reset has passed", () => {
-      const token = new GHToken("test-token");
-      token.valid = true;
-      token.remaining = 0;
-      token.limit = 5000;
-      token.reset = Date.now() - 1000;
+    const now = 1_000_000;
 
-      token.clearExpiredLimits();
+    it.each<{
+      desc: string;
+      state: { valid?: boolean; remaining: number; limit: number; reset: number };
+      clears: boolean;
+    }>([
+      { desc: "valid=true, remaining=0, reset expired", state: { valid: true, remaining: 0, limit: 5000, reset: now - 1000 }, clears: true },
+      { desc: "valid=undefined, remaining=0, reset expired", state: { valid: undefined, remaining: 0, limit: 5000, reset: now - 1000 }, clears: true },
+      { desc: "valid=true, remaining=0, reset in future", state: { valid: true, remaining: 0, limit: 5000, reset: now + 60_000 }, clears: false },
+      { desc: "valid=true, remaining>0, reset expired", state: { valid: true, remaining: 100, limit: 5000, reset: now - 1000 }, clears: false },
+      { desc: "valid=false, remaining=0, reset expired", state: { valid: false, remaining: 0, limit: 5000, reset: now - 1000 }, clears: false },
+    ])("$desc → clears=$clears", ({ state, clears }) => {
+      const token = new GHToken("t");
+      token.valid = state.valid;
+      token.remaining = state.remaining;
+      token.limit = state.limit;
+      token.reset = state.reset;
 
-      expect(token.remaining).toBeUndefined();
-      expect(token.limit).toBeUndefined();
-      expect(token.reset).toBeUndefined();
-    });
+      token.clearExpiredLimits(now);
 
-    it("does not clear when reset is still in the future", () => {
-      const token = new GHToken("test-token");
-      token.valid = true;
-      token.remaining = 0;
-      token.limit = 5000;
-      token.reset = Date.now() + 60_000;
-
-      token.clearExpiredLimits();
-
-      expect(token.remaining).toBe(0);
-      expect(token.limit).toBe(5000);
-      expect(token.reset).toBeDefined();
-    });
-
-    it("does not clear when remaining > 0", () => {
-      const token = new GHToken("test-token");
-      token.valid = true;
-      token.remaining = 100;
-      token.limit = 5000;
-      token.reset = Date.now() - 1000;
-
-      token.clearExpiredLimits();
-
-      expect(token.remaining).toBe(100);
-    });
-
-    it("does not clear for invalid tokens", () => {
-      const token = new GHToken("test-token");
-      token.valid = false;
-      token.remaining = 0;
-      token.limit = 5000;
-      token.reset = Date.now() - 1000;
-
-      token.clearExpiredLimits();
-
-      expect(token.remaining).toBe(0);
-    });
-
-    it("clears when valid is undefined (never validated)", () => {
-      const token = new GHToken("test-token");
-      // valid is undefined
-      token.remaining = 0;
-      token.limit = 5000;
-      token.reset = Date.now() - 1000;
-
-      token.clearExpiredLimits();
-
-      expect(token.remaining).toBeUndefined();
-      expect(token.limit).toBeUndefined();
-      expect(token.reset).toBeUndefined();
+      if (clears) {
+        expect(token.remaining).toBeUndefined();
+        expect(token.limit).toBeUndefined();
+        expect(token.reset).toBeUndefined();
+      } else {
+        expect(token.remaining).toBe(state.remaining);
+      }
     });
   });
 
   describe("available", () => {
-    it("returns true for valid token with remaining requests", () => {
-      const token = new GHToken("test-token");
-      token.valid = true;
-      token.remaining = 100;
-      expect(token.available).toBe(true);
-    });
-
-    it("returns false for invalid token", () => {
-      const token = new GHToken("test-token");
-      token.valid = false;
-      token.remaining = 100;
-      expect(token.available).toBe(false);
-    });
-
-    it("returns false for exhausted token", () => {
-      const token = new GHToken("test-token");
-      token.valid = true;
-      token.remaining = 0;
-      expect(token.available).toBe(false);
-    });
-
-    it("returns true for unvalidated token (valid=undefined treated as falsy)", () => {
-      const token = new GHToken("test-token");
-      // valid is undefined, remaining is undefined
-      expect(token.available).toBeFalsy();
-    });
-
-    it("returns true when remaining is undefined (fresh valid token)", () => {
-      const token = new GHToken("test-token");
-      token.valid = true;
-      // remaining undefined → defaults to 1
-      expect(token.available).toBe(true);
+    it.each([
+      { desc: "valid with remaining", valid: true, remaining: 100, expected: true },
+      { desc: "invalid with remaining", valid: false as const, remaining: 100, expected: false },
+      { desc: "valid but exhausted", valid: true, remaining: 0, expected: false },
+      { desc: "unvalidated (undefined)", valid: undefined, remaining: undefined, expected: false },
+      { desc: "valid, remaining undefined (defaults to 1)", valid: true, remaining: undefined, expected: true },
+    ])("$desc → $expected", ({ valid, remaining, expected }) => {
+      const token = new GHToken("t");
+      token.valid = valid;
+      token.remaining = remaining;
+      if (expected) {
+        expect(token.available).toBe(true);
+      } else {
+        expect(token.available).toBeFalsy();
+      }
     });
   });
 
@@ -288,80 +270,113 @@ describe("GHToken", () => {
       expect(token._appInstallationId).toBeUndefined();
     });
   });
+
+  describe("maskedToken / toString / toJSON / inspect", () => {
+    it.each([
+      { token: "ghp_abcdefghijklmnop", masked: "ghp_***mnop" },
+      { token: "short", masked: "***" },
+      { token: "123456789", masked: "1234***6789" },
+    ])("maskedToken($token) → $masked", ({ token, masked }) => {
+      expect(new GHToken(token).maskedToken).toBe(masked);
+    });
+
+    it("toString includes type", () => {
+      expect(new GHToken("ghp_abcdefghijklmnop").toString()).toBe("[GitHub pat token ghp_***mnop]");
+      expect(new GHToken("ghs_abcdefghijklmnop", { app: true }).toString()).toBe("[GitHub app token ghs_***mnop]");
+    });
+
+    it("toJSON returns serializable object", () => {
+      const token = new GHToken("ghp_abcdefghijklmnop");
+      token.valid = true;
+      token.remaining = 4500;
+      token.limit = 5000;
+      token.reset = 1700000000000;
+      expect(token.toJSON()).toEqual({
+        token: "ghp_***mnop",
+        valid: true,
+        remaining: 4500,
+        limit: 5000,
+        reset: 1700000000000,
+      });
+    });
+
+    it("inspect returns same as toString", () => {
+      const token = new GHToken("ghp_abcdefghijklmnop");
+      expect((token as any)[Symbol.for("nodejs.util.inspect.custom")]()).toBe(token.toString());
+    });
+  });
 });
 
+// --- Pure functions ---
+
 describe("formatDuration", () => {
-  it("returns '<1m' for durations under 1 minute", () => {
-    expect(formatDuration(0)).toBe("<1m");
-    expect(formatDuration(29_000)).toBe("<1m");
-  });
-
-  it("returns minutes for durations under 1 hour", () => {
-    expect(formatDuration(60_000)).toBe("1m");
-    expect(formatDuration(5 * 60_000)).toBe("5m");
-    expect(formatDuration(59 * 60_000)).toBe("59m");
-  });
-
-  it("returns hours for exact hour durations", () => {
-    expect(formatDuration(60 * 60_000)).toBe("1h");
-    expect(formatDuration(2 * 60 * 60_000)).toBe("2h");
-  });
-
-  it("returns hours and minutes for mixed durations", () => {
-    expect(formatDuration(90 * 60_000)).toBe("1h30m");
-    expect(formatDuration(125 * 60_000)).toBe("2h5m");
+  it.each([
+    [0, "<1m"],
+    [29_000, "<1m"],
+    [60_000, "1m"],
+    [5 * 60_000, "5m"],
+    [59 * 60_000, "59m"],
+    [60 * 60_000, "1h"],
+    [2 * 60 * 60_000, "2h"],
+    [90 * 60_000, "1h30m"],
+    [125 * 60_000, "2h5m"],
+  ])("formatDuration(%i) → %s", (ms, expected) => {
+    expect(formatDuration(ms)).toBe(expected);
   });
 });
 
 describe("_base64url", () => {
-  it("encodes a simple string", () => {
-    const encoded = _base64url("hello");
-    // base64url of "hello" = "aGVsbG8"
-    expect(encoded).toBe("aGVsbG8");
+  it("encodes strings to url-safe base64 without padding", () => {
+    expect(_base64url("hello")).toBe("aGVsbG8");
+    expect(_base64url("a")).not.toContain("=");
+    expect(_base64url("subjects?_d")).not.toMatch(/[+/]/);
   });
 
-  it("produces no padding characters", () => {
-    const encoded = _base64url("a");
-    expect(encoded).not.toContain("=");
-  });
-
-  it("replaces + and / with url-safe chars", () => {
-    // Use a string that produces + or / in standard base64
-    const encoded = _base64url("subjects?_d");
-    expect(encoded).not.toContain("+");
-    expect(encoded).not.toContain("/");
-  });
-
-  it("encodes JSON payloads (JWT use case)", () => {
+  it("round-trips JSON payloads (JWT use case)", () => {
     const json = JSON.stringify({ alg: "RS256", typ: "JWT" });
     const encoded = _base64url(json);
     expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/);
-    // Verify round-trip
     const decoded = atob(encoded.replace(/-/g, "+").replace(/_/g, "/"));
     expect(JSON.parse(decoded)).toEqual({ alg: "RS256", typ: "JWT" });
   });
 });
+
+// --- _createAppJWT ---
+
+/** Verifies an RS256 JWT signature against the test key pair. */
+async function verifyJWTSignature(jwt: string, publicKey: CryptoKey) {
+  const parts = jwt.split(".");
+  expect(parts).toHaveLength(3);
+  const data = new TextEncoder().encode(`${parts[0]}.${parts[1]}`);
+  const sig = Uint8Array.from(atob(parts[2]!.replace(/-/g, "+").replace(/_/g, "/")), (c) =>
+    c.charCodeAt(0),
+  );
+  expect(await crypto.subtle.verify("RSASSA-PKCS1-v1_5", publicKey, sig, data)).toBe(true);
+}
+
+/** Extracts the PKCS#1 key bytes from a PKCS#8 DER buffer. */
+function extractPkcs1FromPkcs8(pkcs8Der: ArrayBuffer): Uint8Array {
+  const bytes = new Uint8Array(pkcs8Der);
+  let offset = 1; // skip SEQUENCE tag
+  if (bytes[offset]! & 0x80) { offset += 1 + (bytes[offset]! & 0x7f); } else { offset += 1; }
+  offset += 3; // version INTEGER (02 01 00)
+  offset += 15; // algorithmId SEQUENCE
+  offset += 1; // OCTET STRING tag
+  if (bytes[offset]! & 0x80) { offset += 1 + (bytes[offset]! & 0x7f); } else { offset += 1; }
+  return bytes.slice(offset);
+}
 
 describe("_createAppJWT", () => {
   let keyPair: CryptoKeyPair;
   let pkcs8Pem: string;
 
   beforeAll(async () => {
-    keyPair = await crypto.subtle.generateKey(
-      {
-        name: "RSASSA-PKCS1-v1_5",
-        modulusLength: 2048,
-        publicExponent: new Uint8Array([1, 0, 1]),
-        hash: "SHA-256",
-      },
-      true,
-      ["sign", "verify"],
-    );
-    const pkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
-    pkcs8Pem = `-----BEGIN PRIVATE KEY-----\n${btoa(String.fromCharCode(...new Uint8Array(pkcs8)))}\n-----END PRIVATE KEY-----`;
+    const kp = await getTestKeyPair();
+    keyPair = kp.keyPair;
+    pkcs8Pem = kp.pem;
   });
 
-  it("creates a valid 3-part JWT with PKCS#8 key", async () => {
+  it("creates a valid 3-part JWT with correct header and payload", async () => {
     const jwt = await _createAppJWT("12345", pkcs8Pem);
     const parts = jwt.split(".");
     expect(parts).toHaveLength(3);
@@ -373,78 +388,37 @@ describe("_createAppJWT", () => {
     expect(payload.iss).toBe("12345");
     expect(payload.exp).toBeGreaterThan(payload.iat);
 
-    const data = new TextEncoder().encode(`${parts[0]}.${parts[1]}`);
-    const sig = Uint8Array.from(atob(parts[2]!.replace(/-/g, "+").replace(/_/g, "/")), (c) =>
-      c.charCodeAt(0),
-    );
-    const valid = await crypto.subtle.verify("RSASSA-PKCS1-v1_5", keyPair.publicKey, sig, data);
-    expect(valid).toBe(true);
+    await verifyJWTSignature(jwt, keyPair.publicKey);
   });
 
-  it("handles PEM with escaped newlines", async () => {
-    // Simulate env var with literal \n
-    const escapedPem = pkcs8Pem.replace(/\n/g, "\\n");
-    const jwt = await _createAppJWT("99", escapedPem);
-    expect(jwt.split(".")).toHaveLength(3);
-  });
+  describe("PEM formats", () => {
+    it("PKCS#8 standard PEM", async () => {
+      const jwt = await _createAppJWT("1", pkcs8Pem);
+      await verifyJWTSignature(jwt, keyPair.publicKey);
+    });
 
-  it("handles PKCS#1 (RSA PRIVATE KEY) format", async () => {
-    // Export as PKCS#8, then manually strip the PKCS#8 wrapper to get PKCS#1
-    // We can't easily get raw PKCS#1 from WebCrypto, so we test via the
-    // _pemToKeyData path by providing a PKCS#1-style PEM header
-    const pkcs8Der = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
-    const pkcs8Bytes = new Uint8Array(pkcs8Der);
+    it("PEM with escaped newlines (env var style)", async () => {
+      const jwt = await _createAppJWT("2", pkcs8Pem.replace(/\n/g, "\\n"));
+      await verifyJWTSignature(jwt, keyPair.publicKey);
+    });
 
-    // PKCS#8 wraps PKCS#1 as: SEQUENCE { version, algorithmId, OCTET STRING { pkcs1 } }
-    // We need to extract the PKCS#1 content from the OCTET STRING
-    // Skip outer SEQUENCE tag+length, version (3 bytes), algorithmId (15 bytes)
-    // then parse the OCTET STRING to get the inner PKCS#1 bytes
-    let offset = 0;
-    // Skip SEQUENCE tag
-    offset += 1;
-    // Parse length
-    if (pkcs8Bytes[offset]! & 0x80) {
-      const numLenBytes = pkcs8Bytes[offset]! & 0x7f;
-      offset += 1 + numLenBytes;
-    } else {
-      offset += 1;
-    }
-    // Skip version INTEGER (02 01 00)
-    offset += 3;
-    // Skip algorithmId SEQUENCE (30 0d ...)
-    offset += 15;
-    // Now at OCTET STRING tag (04)
-    offset += 1;
-    // Parse OCTET STRING length
-    if (pkcs8Bytes[offset]! & 0x80) {
-      const numLenBytes = pkcs8Bytes[offset]! & 0x7f;
-      offset += 1 + numLenBytes;
-    } else {
-      offset += 1;
-    }
-    // The rest is PKCS#1 content
-    const pkcs1Bytes = pkcs8Bytes.slice(offset);
-    const pkcs1Base64 = btoa(String.fromCharCode(...pkcs1Bytes));
-    const pkcs1Pem = `-----BEGIN RSA PRIVATE KEY-----\n${pkcs1Base64}\n-----END RSA PRIVATE KEY-----`;
+    it("PKCS#1 (RSA PRIVATE KEY) format", async () => {
+      const pkcs8Der = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+      const pkcs1Bytes = extractPkcs1FromPkcs8(pkcs8Der);
+      const pkcs1Pem = `-----BEGIN RSA PRIVATE KEY-----\n${btoa(String.fromCharCode(...pkcs1Bytes))}\n-----END RSA PRIVATE KEY-----`;
 
-    const jwt = await _createAppJWT("42", pkcs1Pem);
-    const parts = jwt.split(".");
-    expect(parts).toHaveLength(3);
-
-    // Verify the signature is valid (proves PKCS#1 -> PKCS#8 conversion worked)
-    const data = new TextEncoder().encode(`${parts[0]}.${parts[1]}`);
-    const sig = Uint8Array.from(atob(parts[2]!.replace(/-/g, "+").replace(/_/g, "/")), (c) =>
-      c.charCodeAt(0),
-    );
-    const valid = await crypto.subtle.verify("RSASSA-PKCS1-v1_5", keyPair.publicKey, sig, data);
-    expect(valid).toBe(true);
+      const jwt = await _createAppJWT("3", pkcs1Pem);
+      await verifyJWTSignature(jwt, keyPair.publicKey);
+    });
   });
 });
 
+// --- Token registry functions ---
+
 describe("getGHToken", () => {
+  beforeEach(() => { ghTokens.length = 0; });
+
   it("returns the token with highest remaining quota", () => {
-    // Clear and populate ghTokens
-    ghTokens.length = 0;
     const t1 = new GHToken("tok1");
     t1.valid = true;
     t1.remaining = 100;
@@ -452,46 +426,41 @@ describe("getGHToken", () => {
     t2.valid = true;
     t2.remaining = 500;
     ghTokens.push(t1, t2);
-
     expect(getGHToken()).toBe(t2);
   });
 
   it("returns undefined when no tokens are available", () => {
-    ghTokens.length = 0;
     const t = new GHToken("tok");
     t.valid = false;
     ghTokens.push(t);
-
     expect(getGHToken()).toBeUndefined();
   });
 
   it("clears expired limits before selecting", () => {
-    ghTokens.length = 0;
     const t = new GHToken("tok");
     t.valid = true;
     t.remaining = 0;
     t.limit = 5000;
-    t.reset = Date.now() - 1000; // expired
+    t.reset = Date.now() - 1000;
     ghTokens.push(t);
 
     const result = getGHToken();
-    // After clearing, remaining becomes undefined → available (remaining ?? 1 > 0)
     expect(result).toBe(t);
     expect(t.remaining).toBeUndefined();
   });
 
   it("skips exhausted tokens that have not expired", () => {
-    ghTokens.length = 0;
     const t = new GHToken("tok");
     t.valid = true;
     t.remaining = 0;
     t.limit = 5000;
-    t.reset = Date.now() + 60_000; // still in the future
+    t.reset = Date.now() + 60_000;
     ghTokens.push(t);
-
     expect(getGHToken()).toBeUndefined();
   });
 });
+
+// --- Async token management (shared fetch spy setup) ---
 
 describe("ensureTokensValidated", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
@@ -501,39 +470,25 @@ describe("ensureTokensValidated", () => {
     ghTokens.length = 0;
     ensureTokensValidated.reset();
   });
+  afterEach(() => { fetchSpy.mockRestore(); });
 
-  afterEach(() => {
-    fetchSpy.mockRestore();
-  });
-
-  it("validates tokens and stops after first available", async () => {
-    const t1 = new GHToken("tok1");
-    const t2 = new GHToken("tok2");
-    ghTokens.push(t1, t2);
-
+  it("validates tokens until one is available", async () => {
+    ghTokens.push(new GHToken("tok1"), new GHToken("tok2"));
     fetchSpy.mockResolvedValue(mockResponse(200, rateLimitHeaders(4000, 5000)));
-
     await ensureTokensValidated();
-
-    expect(t1.valid).toBe(true);
-    expect(t1.remaining).toBe(4000);
+    expect(ghTokens[0]!.valid).toBe(true);
+    expect(ghTokens[0]!.remaining).toBe(4000);
   });
 
-  it("falls back to revalidation when no token is available after validation", async () => {
-    const t = new GHToken("tok");
-    ghTokens.push(t);
-
-    // Validate returns 401 (invalid) — token not available, triggers revalidation path
+  it("falls back to revalidation when no token is available", async () => {
+    ghTokens.push(new GHToken("tok"));
     fetchSpy.mockResolvedValue(mockResponse(401, rateLimitHeaders(0, 0)));
-
     await ensureTokensValidated();
-
-    // Initial validation marks invalid, revalidation is attempted
-    expect(t.valid).toBe(false);
+    expect(ghTokens[0]!.valid).toBe(false);
     expect(fetchSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("works with no tokens (empty registry)", async () => {
+  it("works with empty registry", async () => {
     await ensureTokensValidated();
     expect(fetchSpy).not.toHaveBeenCalled();
   });
@@ -547,22 +502,14 @@ describe("ensureAllTokensValidated", () => {
     ghTokens.length = 0;
     ensureAppToken.reset();
   });
-
-  afterEach(() => {
-    fetchSpy.mockRestore();
-  });
+  afterEach(() => { fetchSpy.mockRestore(); });
 
   it("validates all tokens", async () => {
-    const t1 = new GHToken("tok1");
-    const t2 = new GHToken("tok2");
-    ghTokens.push(t1, t2);
-
+    ghTokens.push(new GHToken("tok1"), new GHToken("tok2"));
     fetchSpy.mockResolvedValue(mockResponse(200, rateLimitHeaders(3000, 5000)));
-
     await ensureAllTokensValidated();
-
-    expect(t1.valid).toBe(true);
-    expect(t2.valid).toBe(true);
+    expect(ghTokens[0]!.valid).toBe(true);
+    expect(ghTokens[1]!.valid).toBe(true);
   });
 });
 
@@ -573,33 +520,25 @@ describe("revalidateGHTokens", () => {
     fetchSpy = vi.spyOn(globalThis, "fetch");
     ghTokens.length = 0;
   });
-
-  afterEach(() => {
-    fetchSpy.mockRestore();
-  });
+  afterEach(() => { fetchSpy.mockRestore(); });
 
   it("revalidates stale tokens", async () => {
     const t = new GHToken("tok");
     t.valid = true;
-    t._lastValidated = Date.now() - 120_000; // stale
+    t._lastValidated = Date.now() - 120_000;
     ghTokens.push(t);
-
     fetchSpy.mockResolvedValue(mockResponse(200, rateLimitHeaders(4500, 5000)));
-
-    const result = await revalidateGHTokens();
-    expect(result).toBe(true);
+    expect(await revalidateGHTokens()).toBe(true);
     expect(t.remaining).toBe(4500);
   });
 
-  it("returns false when no tokens are stale and one is available", async () => {
+  it("short-circuits when no tokens are stale and one is available", async () => {
     const t = new GHToken("tok");
     t.valid = true;
     t.remaining = 1000;
-    t._lastValidated = Date.now(); // fresh
+    t._lastValidated = Date.now();
     ghTokens.push(t);
-
-    const result = await revalidateGHTokens();
-    expect(result).toBe(false);
+    expect(await revalidateGHTokens()).toBe(false);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
@@ -607,12 +546,9 @@ describe("revalidateGHTokens", () => {
     const t = new GHToken("tok");
     t._lastValidated = Date.now() - 120_000;
     ghTokens.push(t);
-
     fetchSpy.mockResolvedValue(mockResponse(200, rateLimitHeaders(4000, 5000)));
-
     const [r1, r2] = await Promise.all([revalidateGHTokens(), revalidateGHTokens()]);
     expect(r1).toBe(r2);
-    // Only one set of validations should have happened
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 });
@@ -625,38 +561,25 @@ describe("acquireGHToken", () => {
     ghTokens.length = 0;
     ensureTokensValidated.reset();
   });
-
-  afterEach(() => {
-    fetchSpy.mockRestore();
-  });
+  afterEach(() => { fetchSpy.mockRestore(); });
 
   it("returns the best available token after validation", async () => {
     const t = new GHToken("tok");
     ghTokens.push(t);
-
     fetchSpy.mockResolvedValue(mockResponse(200, rateLimitHeaders(4000, 5000)));
-
-    const result = await acquireGHToken();
-    expect(result).toBe(t);
+    expect(await acquireGHToken()).toBe(t);
     expect(t.valid).toBe(true);
   });
 
   it("returns undefined when all tokens are invalid", async () => {
-    const t = new GHToken("tok");
-    ghTokens.push(t);
-
+    ghTokens.push(new GHToken("tok"));
     fetchSpy.mockResolvedValue(mockResponse(401, rateLimitHeaders(0, 0)));
-
-    const result = await acquireGHToken();
-    expect(result).toBeUndefined();
+    expect(await acquireGHToken()).toBeUndefined();
   });
 
-  it("revalidates and returns token when first getGHToken returns nothing", async () => {
+  it("revalidates when first pass yields no available token", async () => {
     const t = new GHToken("tok");
     ghTokens.push(t);
-
-    // First call (ensureTokensValidated) marks token as exhausted
-    // Second call (revalidateGHTokens) restores it
     let callCount = 0;
     fetchSpy.mockImplementation(async () => {
       callCount++;
@@ -665,73 +588,13 @@ describe("acquireGHToken", () => {
       }
       return mockResponse(200, rateLimitHeaders(4000, 5000));
     });
-
-    const result = await acquireGHToken();
-    // After revalidation, the token should be available
-    expect(result).toBe(t);
+    expect(await acquireGHToken()).toBe(t);
   });
 });
 
-describe("GHToken utility methods", () => {
-  describe("maskedToken", () => {
-    it("masks middle of long tokens", () => {
-      const token = new GHToken("ghp_abcdefghijklmnop");
-      expect(token.maskedToken).toBe("ghp_***mnop");
-    });
+// --- GitHub App token flow ---
 
-    it("returns *** for short tokens", () => {
-      const token = new GHToken("short");
-      expect(token.maskedToken).toBe("***");
-    });
-
-    it("masks tokens of exactly 9 chars (boundary)", () => {
-      const token = new GHToken("123456789");
-      expect(token.maskedToken).toBe("1234***6789");
-    });
-  });
-
-  describe("toJSON", () => {
-    it("returns serializable object with masked token", () => {
-      const token = new GHToken("ghp_abcdefghijklmnop");
-      token.valid = true;
-      token.remaining = 4500;
-      token.limit = 5000;
-      token.reset = 1700000000000;
-
-      const json = token.toJSON();
-      expect(json).toEqual({
-        token: "ghp_***mnop",
-        valid: true,
-        remaining: 4500,
-        limit: 5000,
-        reset: 1700000000000,
-      });
-    });
-  });
-
-  describe("toString", () => {
-    it("includes pat type for regular tokens", () => {
-      const token = new GHToken("ghp_abcdefghijklmnop");
-      expect(token.toString()).toBe("[GitHub pat token ghp_***mnop]");
-    });
-
-    it("includes app type for app tokens", () => {
-      const token = new GHToken("ghs_abcdefghijklmnop", { app: true });
-      expect(token.toString()).toBe("[GitHub app token ghs_***mnop]");
-    });
-  });
-
-  describe("Symbol inspect", () => {
-    it("returns same as toString", () => {
-      const token = new GHToken("ghp_abcdefghijklmnop");
-      const inspectKey = Symbol.for("nodejs.util.inspect.custom");
-      const inspect = (token as any)[inspectKey]();
-      expect(inspect).toBe(token.toString());
-    });
-  });
-});
-
-describe("_refreshAppToken via ensureAppToken", () => {
+describe("ensureAppToken (_refreshAppToken)", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
   const originalEnv = { ...process.env };
 
@@ -746,58 +609,26 @@ describe("_refreshAppToken via ensureAppToken", () => {
     process.env = { ...originalEnv };
   });
 
-  it("does nothing when GH_APP_ID is not set", async () => {
-    delete process.env.GH_APP_ID;
-    delete process.env.GH_APP_PRIVATE_KEY;
-
+  it.each([
+    { desc: "GH_APP_ID missing", id: undefined, key: "some-key" },
+    { desc: "GH_APP_PRIVATE_KEY missing", id: "123", key: undefined },
+    { desc: "both missing", id: undefined, key: undefined },
+  ])("does nothing when $desc", async ({ id, key }) => {
+    if (id) process.env.GH_APP_ID = id; else delete process.env.GH_APP_ID;
+    if (key) process.env.GH_APP_PRIVATE_KEY = key; else delete process.env.GH_APP_PRIVATE_KEY;
     await ensureAppToken();
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it("does nothing when GH_APP_PRIVATE_KEY is not set", async () => {
-    process.env.GH_APP_ID = "123";
-    delete process.env.GH_APP_PRIVATE_KEY;
-
-    await ensureAppToken();
-    expect(fetchSpy).not.toHaveBeenCalled();
-  });
-
-  it("fetches installations and creates tokens", async () => {
-    const keyPair = await crypto.subtle.generateKey(
-      {
-        name: "RSASSA-PKCS1-v1_5",
-        modulusLength: 2048,
-        publicExponent: new Uint8Array([1, 0, 1]),
-        hash: "SHA-256",
-      },
-      true,
-      ["sign", "verify"],
-    );
-    const pkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
-    const pem = `-----BEGIN PRIVATE KEY-----\n${btoa(String.fromCharCode(...new Uint8Array(pkcs8)))}\n-----END PRIVATE KEY-----`;
-
+  async function setupAppEnv() {
+    const { pem } = await getTestKeyPair();
     process.env.GH_APP_ID = "99";
     process.env.GH_APP_PRIVATE_KEY = pem;
+  }
 
-    const expiresAt = new Date(Date.now() + 3600_000).toISOString();
-
-    fetchSpy.mockImplementation(async (url: string | URL | Request) => {
-      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
-      if (urlStr.includes("/app/installations") && !urlStr.includes("/access_tokens")) {
-        return new Response(JSON.stringify([{ id: 42 }]), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
-      }
-      if (urlStr.includes("/access_tokens")) {
-        return new Response(
-          JSON.stringify({ token: "ghs_installtoken123456", expires_at: expiresAt }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        );
-      }
-      // validate call
-      return mockResponse(200, rateLimitHeaders(4500, 5000));
-    });
+  it("fetches installations and creates tokens", async () => {
+    await setupAppEnv();
+    mockAppFetch(fetchSpy);
 
     await ensureAppToken();
 
@@ -808,148 +639,43 @@ describe("_refreshAppToken via ensureAppToken", () => {
   });
 
   it("updates existing app token instead of creating new one", async () => {
-    const keyPair = await crypto.subtle.generateKey(
-      {
-        name: "RSASSA-PKCS1-v1_5",
-        modulusLength: 2048,
-        publicExponent: new Uint8Array([1, 0, 1]),
-        hash: "SHA-256",
-      },
-      true,
-      ["sign", "verify"],
-    );
-    const pkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
-    const pem = `-----BEGIN PRIVATE KEY-----\n${btoa(String.fromCharCode(...new Uint8Array(pkcs8)))}\n-----END PRIVATE KEY-----`;
+    await setupAppEnv();
 
-    process.env.GH_APP_ID = "99";
-    process.env.GH_APP_PRIVATE_KEY = pem;
-
-    // Pre-existing app token for installation 42
     const existing = new GHToken("old-token", { app: true, appInstallationId: "42" });
     existing.valid = true;
     existing.remaining = 100;
     ghTokens.push(existing);
 
-    const expiresAt = new Date(Date.now() + 3600_000).toISOString();
-
-    fetchSpy.mockImplementation(async (url: string | URL | Request) => {
-      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
-      if (urlStr.includes("/app/installations") && !urlStr.includes("/access_tokens")) {
-        return new Response(JSON.stringify([{ id: 42 }]), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
-      }
-      if (urlStr.includes("/access_tokens")) {
-        return new Response(
-          JSON.stringify({ token: "ghs_newtoken123456789", expires_at: expiresAt }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        );
-      }
-      return mockResponse(200, rateLimitHeaders(4500, 5000));
+    mockAppFetch(fetchSpy, {
+      accessToken: {
+        token: "ghs_newtoken123456789",
+        expires_at: new Date(Date.now() + 3600_000).toISOString(),
+      },
     });
 
     await ensureAppToken();
 
-    // Should have updated the existing token, not added a new one
     const appTokens = ghTokens.filter((t) => t._appInstallationId === "42");
     expect(appTokens).toHaveLength(1);
     expect(appTokens[0]!.token).toBe("ghs_newtoken123456789");
   });
 
   it("handles installation token fetch failure gracefully", async () => {
-    const keyPair = await crypto.subtle.generateKey(
-      {
-        name: "RSASSA-PKCS1-v1_5",
-        modulusLength: 2048,
-        publicExponent: new Uint8Array([1, 0, 1]),
-        hash: "SHA-256",
-      },
-      true,
-      ["sign", "verify"],
-    );
-    const pkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
-    const pem = `-----BEGIN PRIVATE KEY-----\n${btoa(String.fromCharCode(...new Uint8Array(pkcs8)))}\n-----END PRIVATE KEY-----`;
-
-    process.env.GH_APP_ID = "99";
-    process.env.GH_APP_PRIVATE_KEY = pem;
-
-    fetchSpy.mockImplementation(async (url: string | URL | Request) => {
-      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
-      if (urlStr.includes("/app/installations") && !urlStr.includes("/access_tokens")) {
-        return new Response(JSON.stringify([{ id: 42 }]), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
-      }
-      if (urlStr.includes("/access_tokens")) {
-        return new Response(null, { status: 500 });
-      }
-      return mockResponse(200, rateLimitHeaders(4500, 5000));
-    });
-
-    // Should not throw
+    await setupAppEnv();
+    mockAppFetch(fetchSpy, { accessTokenStatus: 500 });
     await ensureAppToken();
     expect(ghTokens.filter((t) => t._app)).toHaveLength(0);
   });
 
   it("handles installations fetch failure gracefully", async () => {
-    const keyPair = await crypto.subtle.generateKey(
-      {
-        name: "RSASSA-PKCS1-v1_5",
-        modulusLength: 2048,
-        publicExponent: new Uint8Array([1, 0, 1]),
-        hash: "SHA-256",
-      },
-      true,
-      ["sign", "verify"],
-    );
-    const pkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
-    const pem = `-----BEGIN PRIVATE KEY-----\n${btoa(String.fromCharCode(...new Uint8Array(pkcs8)))}\n-----END PRIVATE KEY-----`;
-
-    process.env.GH_APP_ID = "99";
-    process.env.GH_APP_PRIVATE_KEY = pem;
-
-    fetchSpy.mockImplementation(async (url: string | URL | Request) => {
-      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
-      if (urlStr.includes("/app/installations")) {
-        return new Response(null, { status: 403 });
-      }
-      return mockResponse(200, rateLimitHeaders(4500, 5000));
-    });
-
-    // Should not throw
+    await setupAppEnv();
+    mockAppFetch(fetchSpy, { installationsStatus: 403 });
     await ensureAppToken();
   });
 
   it("handles empty installations list", async () => {
-    const keyPair = await crypto.subtle.generateKey(
-      {
-        name: "RSASSA-PKCS1-v1_5",
-        modulusLength: 2048,
-        publicExponent: new Uint8Array([1, 0, 1]),
-        hash: "SHA-256",
-      },
-      true,
-      ["sign", "verify"],
-    );
-    const pkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
-    const pem = `-----BEGIN PRIVATE KEY-----\n${btoa(String.fromCharCode(...new Uint8Array(pkcs8)))}\n-----END PRIVATE KEY-----`;
-
-    process.env.GH_APP_ID = "99";
-    process.env.GH_APP_PRIVATE_KEY = pem;
-
-    fetchSpy.mockImplementation(async (url: string | URL | Request) => {
-      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
-      if (urlStr.includes("/app/installations")) {
-        return new Response(JSON.stringify([]), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        });
-      }
-      return mockResponse(200, rateLimitHeaders(4500, 5000));
-    });
-
+    await setupAppEnv();
+    mockAppFetch(fetchSpy, { installations: [] });
     await ensureAppToken();
     expect(ghTokens.filter((t) => t._app)).toHaveLength(0);
   });

--- a/test/github_token.test.ts
+++ b/test/github_token.test.ts
@@ -1,5 +1,15 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
 import { GHToken } from "~/utils/github_token";
+import {
+  formatDuration,
+  _base64url,
+  _createAppJWT,
+  getGHToken,
+  ghTokens,
+  ensureTokensValidated,
+  ensureAllTokensValidated,
+  revalidateGHTokens,
+} from "~/utils/github_token";
 
 function mockResponse(status: number, headers: Record<string, string> = {}): Response {
   return new Response(null, { status, headers });
@@ -256,5 +266,349 @@ describe("GHToken", () => {
       // remaining undefined → defaults to 1
       expect(token.available).toBe(true);
     });
+  });
+
+  describe("constructor", () => {
+    it("sets app and appInstallationId from opts", () => {
+      const token = new GHToken("tok", { app: true, appInstallationId: "123" });
+      expect(token._app).toBe(true);
+      expect(token._appInstallationId).toBe("123");
+    });
+
+    it("defaults optional fields to undefined", () => {
+      const token = new GHToken("tok");
+      expect(token.valid).toBeUndefined();
+      expect(token.remaining).toBeUndefined();
+      expect(token.limit).toBeUndefined();
+      expect(token.reset).toBeUndefined();
+      expect(token._lastValidated).toBeUndefined();
+      expect(token._app).toBeUndefined();
+      expect(token._appInstallationId).toBeUndefined();
+    });
+  });
+});
+
+describe("formatDuration", () => {
+  it("returns '<1m' for durations under 1 minute", () => {
+    expect(formatDuration(0)).toBe("<1m");
+    expect(formatDuration(29_000)).toBe("<1m");
+  });
+
+  it("returns minutes for durations under 1 hour", () => {
+    expect(formatDuration(60_000)).toBe("1m");
+    expect(formatDuration(5 * 60_000)).toBe("5m");
+    expect(formatDuration(59 * 60_000)).toBe("59m");
+  });
+
+  it("returns hours for exact hour durations", () => {
+    expect(formatDuration(60 * 60_000)).toBe("1h");
+    expect(formatDuration(2 * 60 * 60_000)).toBe("2h");
+  });
+
+  it("returns hours and minutes for mixed durations", () => {
+    expect(formatDuration(90 * 60_000)).toBe("1h30m");
+    expect(formatDuration(125 * 60_000)).toBe("2h5m");
+  });
+});
+
+describe("_base64url", () => {
+  it("encodes a simple string", () => {
+    const encoded = _base64url("hello");
+    // base64url of "hello" = "aGVsbG8"
+    expect(encoded).toBe("aGVsbG8");
+  });
+
+  it("produces no padding characters", () => {
+    const encoded = _base64url("a");
+    expect(encoded).not.toContain("=");
+  });
+
+  it("replaces + and / with url-safe chars", () => {
+    // Use a string that produces + or / in standard base64
+    const encoded = _base64url("subjects?_d");
+    expect(encoded).not.toContain("+");
+    expect(encoded).not.toContain("/");
+  });
+
+  it("encodes JSON payloads (JWT use case)", () => {
+    const json = JSON.stringify({ alg: "RS256", typ: "JWT" });
+    const encoded = _base64url(json);
+    expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/);
+    // Verify round-trip
+    const decoded = atob(encoded.replace(/-/g, "+").replace(/_/g, "/"));
+    expect(JSON.parse(decoded)).toEqual({ alg: "RS256", typ: "JWT" });
+  });
+});
+
+describe("_createAppJWT", () => {
+  let keyPair: CryptoKeyPair;
+  let pkcs8Pem: string;
+
+  beforeAll(async () => {
+    keyPair = await crypto.subtle.generateKey(
+      {
+        name: "RSASSA-PKCS1-v1_5",
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      true,
+      ["sign", "verify"],
+    );
+    const pkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+    pkcs8Pem = `-----BEGIN PRIVATE KEY-----\n${btoa(String.fromCharCode(...new Uint8Array(pkcs8)))}\n-----END PRIVATE KEY-----`;
+  });
+
+  it("creates a valid 3-part JWT with PKCS#8 key", async () => {
+    const jwt = await _createAppJWT("12345", pkcs8Pem);
+    const parts = jwt.split(".");
+    expect(parts).toHaveLength(3);
+
+    const header = JSON.parse(atob(parts[0]!.replace(/-/g, "+").replace(/_/g, "/")));
+    expect(header).toEqual({ alg: "RS256", typ: "JWT" });
+
+    const payload = JSON.parse(atob(parts[1]!.replace(/-/g, "+").replace(/_/g, "/")));
+    expect(payload.iss).toBe("12345");
+    expect(payload.exp).toBeGreaterThan(payload.iat);
+
+    const data = new TextEncoder().encode(`${parts[0]}.${parts[1]}`);
+    const sig = Uint8Array.from(atob(parts[2]!.replace(/-/g, "+").replace(/_/g, "/")), (c) =>
+      c.charCodeAt(0),
+    );
+    const valid = await crypto.subtle.verify("RSASSA-PKCS1-v1_5", keyPair.publicKey, sig, data);
+    expect(valid).toBe(true);
+  });
+
+  it("handles PEM with escaped newlines", async () => {
+    // Simulate env var with literal \n
+    const escapedPem = pkcs8Pem.replace(/\n/g, "\\n");
+    const jwt = await _createAppJWT("99", escapedPem);
+    expect(jwt.split(".")).toHaveLength(3);
+  });
+
+  it("handles PKCS#1 (RSA PRIVATE KEY) format", async () => {
+    // Export as PKCS#8, then manually strip the PKCS#8 wrapper to get PKCS#1
+    // We can't easily get raw PKCS#1 from WebCrypto, so we test via the
+    // _pemToKeyData path by providing a PKCS#1-style PEM header
+    const pkcs8Der = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+    const pkcs8Bytes = new Uint8Array(pkcs8Der);
+
+    // PKCS#8 wraps PKCS#1 as: SEQUENCE { version, algorithmId, OCTET STRING { pkcs1 } }
+    // We need to extract the PKCS#1 content from the OCTET STRING
+    // Skip outer SEQUENCE tag+length, version (3 bytes), algorithmId (15 bytes)
+    // then parse the OCTET STRING to get the inner PKCS#1 bytes
+    let offset = 0;
+    // Skip SEQUENCE tag
+    offset += 1;
+    // Parse length
+    if (pkcs8Bytes[offset]! & 0x80) {
+      const numLenBytes = pkcs8Bytes[offset]! & 0x7f;
+      offset += 1 + numLenBytes;
+    } else {
+      offset += 1;
+    }
+    // Skip version INTEGER (02 01 00)
+    offset += 3;
+    // Skip algorithmId SEQUENCE (30 0d ...)
+    offset += 15;
+    // Now at OCTET STRING tag (04)
+    offset += 1;
+    // Parse OCTET STRING length
+    if (pkcs8Bytes[offset]! & 0x80) {
+      const numLenBytes = pkcs8Bytes[offset]! & 0x7f;
+      offset += 1 + numLenBytes;
+    } else {
+      offset += 1;
+    }
+    // The rest is PKCS#1 content
+    const pkcs1Bytes = pkcs8Bytes.slice(offset);
+    const pkcs1Base64 = btoa(String.fromCharCode(...pkcs1Bytes));
+    const pkcs1Pem = `-----BEGIN RSA PRIVATE KEY-----\n${pkcs1Base64}\n-----END RSA PRIVATE KEY-----`;
+
+    const jwt = await _createAppJWT("42", pkcs1Pem);
+    const parts = jwt.split(".");
+    expect(parts).toHaveLength(3);
+
+    // Verify the signature is valid (proves PKCS#1 -> PKCS#8 conversion worked)
+    const data = new TextEncoder().encode(`${parts[0]}.${parts[1]}`);
+    const sig = Uint8Array.from(atob(parts[2]!.replace(/-/g, "+").replace(/_/g, "/")), (c) =>
+      c.charCodeAt(0),
+    );
+    const valid = await crypto.subtle.verify("RSASSA-PKCS1-v1_5", keyPair.publicKey, sig, data);
+    expect(valid).toBe(true);
+  });
+});
+
+describe("getGHToken", () => {
+  it("returns the token with highest remaining quota", () => {
+    // Clear and populate ghTokens
+    ghTokens.length = 0;
+    const t1 = new GHToken("tok1");
+    t1.valid = true;
+    t1.remaining = 100;
+    const t2 = new GHToken("tok2");
+    t2.valid = true;
+    t2.remaining = 500;
+    ghTokens.push(t1, t2);
+
+    expect(getGHToken()).toBe(t2);
+  });
+
+  it("returns undefined when no tokens are available", () => {
+    ghTokens.length = 0;
+    const t = new GHToken("tok");
+    t.valid = false;
+    ghTokens.push(t);
+
+    expect(getGHToken()).toBeUndefined();
+  });
+
+  it("clears expired limits before selecting", () => {
+    ghTokens.length = 0;
+    const t = new GHToken("tok");
+    t.valid = true;
+    t.remaining = 0;
+    t.limit = 5000;
+    t.reset = Date.now() - 1000; // expired
+    ghTokens.push(t);
+
+    const result = getGHToken();
+    // After clearing, remaining becomes undefined → available (remaining ?? 1 > 0)
+    expect(result).toBe(t);
+    expect(t.remaining).toBeUndefined();
+  });
+
+  it("skips exhausted tokens that have not expired", () => {
+    ghTokens.length = 0;
+    const t = new GHToken("tok");
+    t.valid = true;
+    t.remaining = 0;
+    t.limit = 5000;
+    t.reset = Date.now() + 60_000; // still in the future
+    ghTokens.push(t);
+
+    expect(getGHToken()).toBeUndefined();
+  });
+});
+
+describe("ensureTokensValidated", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+    ghTokens.length = 0;
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("validates tokens and stops after first available", async () => {
+    const t1 = new GHToken("tok1");
+    const t2 = new GHToken("tok2");
+    ghTokens.push(t1, t2);
+
+    fetchSpy.mockResolvedValue(mockResponse(200, rateLimitHeaders(4000, 5000)));
+
+    await ensureTokensValidated();
+
+    expect(t1.valid).toBe(true);
+    expect(t1.remaining).toBe(4000);
+  });
+
+  it("falls back to revalidation when no token is available after validation", async () => {
+    const t = new GHToken("tok");
+    ghTokens.push(t);
+
+    // Validate returns 401 (invalid) — token not available, triggers revalidation path
+    fetchSpy.mockResolvedValue(mockResponse(401, rateLimitHeaders(0, 0)));
+
+    await ensureTokensValidated();
+
+    // Initial validation marks invalid, revalidation is attempted
+    expect(t.valid).toBe(false);
+    expect(fetchSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("works with no tokens (empty registry)", async () => {
+    await ensureTokensValidated();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("ensureAllTokensValidated", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+    ghTokens.length = 0;
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("validates all tokens", async () => {
+    const t1 = new GHToken("tok1");
+    const t2 = new GHToken("tok2");
+    ghTokens.push(t1, t2);
+
+    fetchSpy.mockResolvedValue(mockResponse(200, rateLimitHeaders(3000, 5000)));
+
+    await ensureAllTokensValidated();
+
+    expect(t1.valid).toBe(true);
+    expect(t2.valid).toBe(true);
+  });
+});
+
+describe("revalidateGHTokens", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+    ghTokens.length = 0;
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("revalidates stale tokens", async () => {
+    const t = new GHToken("tok");
+    t.valid = true;
+    t._lastValidated = Date.now() - 120_000; // stale
+    ghTokens.push(t);
+
+    fetchSpy.mockResolvedValue(mockResponse(200, rateLimitHeaders(4500, 5000)));
+
+    const result = await revalidateGHTokens();
+    expect(result).toBe(true);
+    expect(t.remaining).toBe(4500);
+  });
+
+  it("returns false when no tokens are stale and one is available", async () => {
+    const t = new GHToken("tok");
+    t.valid = true;
+    t.remaining = 1000;
+    t._lastValidated = Date.now(); // fresh
+    ghTokens.push(t);
+
+    const result = await revalidateGHTokens();
+    expect(result).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("coalesces concurrent calls", async () => {
+    const t = new GHToken("tok");
+    t._lastValidated = Date.now() - 120_000;
+    ghTokens.push(t);
+
+    fetchSpy.mockResolvedValue(mockResponse(200, rateLimitHeaders(4000, 5000)));
+
+    const [r1, r2] = await Promise.all([revalidateGHTokens(), revalidateGHTokens()]);
+    expect(r1).toBe(r2);
+    // Only one set of validations should have happened
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/github_token.test.ts
+++ b/test/github_token.test.ts
@@ -10,6 +10,7 @@ import {
   ensureAllTokensValidated,
   revalidateGHTokens,
   ensureAppToken,
+  acquireGHToken,
 } from "~/utils/github_token";
 
 function mockResponse(status: number, headers: Record<string, string> = {}): Response {
@@ -613,5 +614,343 @@ describe("revalidateGHTokens", () => {
     expect(r1).toBe(r2);
     // Only one set of validations should have happened
     expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("acquireGHToken", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+    ghTokens.length = 0;
+    ensureTokensValidated.reset();
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("returns the best available token after validation", async () => {
+    const t = new GHToken("tok");
+    ghTokens.push(t);
+
+    fetchSpy.mockResolvedValue(mockResponse(200, rateLimitHeaders(4000, 5000)));
+
+    const result = await acquireGHToken();
+    expect(result).toBe(t);
+    expect(t.valid).toBe(true);
+  });
+
+  it("returns undefined when all tokens are invalid", async () => {
+    const t = new GHToken("tok");
+    ghTokens.push(t);
+
+    fetchSpy.mockResolvedValue(mockResponse(401, rateLimitHeaders(0, 0)));
+
+    const result = await acquireGHToken();
+    expect(result).toBeUndefined();
+  });
+
+  it("revalidates and returns token when first getGHToken returns nothing", async () => {
+    const t = new GHToken("tok");
+    ghTokens.push(t);
+
+    // First call (ensureTokensValidated) marks token as exhausted
+    // Second call (revalidateGHTokens) restores it
+    let callCount = 0;
+    fetchSpy.mockImplementation(async () => {
+      callCount++;
+      if (callCount <= 1) {
+        return mockResponse(200, rateLimitHeaders(0, 5000, Math.floor(Date.now() / 1000) - 1));
+      }
+      return mockResponse(200, rateLimitHeaders(4000, 5000));
+    });
+
+    const result = await acquireGHToken();
+    // After revalidation, the token should be available
+    expect(result).toBe(t);
+  });
+});
+
+describe("GHToken utility methods", () => {
+  describe("maskedToken", () => {
+    it("masks middle of long tokens", () => {
+      const token = new GHToken("ghp_abcdefghijklmnop");
+      expect(token.maskedToken).toBe("ghp_***mnop");
+    });
+
+    it("returns *** for short tokens", () => {
+      const token = new GHToken("short");
+      expect(token.maskedToken).toBe("***");
+    });
+
+    it("masks tokens of exactly 9 chars (boundary)", () => {
+      const token = new GHToken("123456789");
+      expect(token.maskedToken).toBe("1234***6789");
+    });
+  });
+
+  describe("toJSON", () => {
+    it("returns serializable object with masked token", () => {
+      const token = new GHToken("ghp_abcdefghijklmnop");
+      token.valid = true;
+      token.remaining = 4500;
+      token.limit = 5000;
+      token.reset = 1700000000000;
+
+      const json = token.toJSON();
+      expect(json).toEqual({
+        token: "ghp_***mnop",
+        valid: true,
+        remaining: 4500,
+        limit: 5000,
+        reset: 1700000000000,
+      });
+    });
+  });
+
+  describe("toString", () => {
+    it("includes pat type for regular tokens", () => {
+      const token = new GHToken("ghp_abcdefghijklmnop");
+      expect(token.toString()).toBe("[GitHub pat token ghp_***mnop]");
+    });
+
+    it("includes app type for app tokens", () => {
+      const token = new GHToken("ghs_abcdefghijklmnop", { app: true });
+      expect(token.toString()).toBe("[GitHub app token ghs_***mnop]");
+    });
+  });
+
+  describe("Symbol inspect", () => {
+    it("returns same as toString", () => {
+      const token = new GHToken("ghp_abcdefghijklmnop");
+      const inspectKey = Symbol.for("nodejs.util.inspect.custom");
+      const inspect = (token as any)[inspectKey]();
+      expect(inspect).toBe(token.toString());
+    });
+  });
+});
+
+describe("_refreshAppToken via ensureAppToken", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch");
+    ghTokens.length = 0;
+    ensureAppToken.reset();
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    process.env = { ...originalEnv };
+  });
+
+  it("does nothing when GH_APP_ID is not set", async () => {
+    delete process.env.GH_APP_ID;
+    delete process.env.GH_APP_PRIVATE_KEY;
+
+    await ensureAppToken();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when GH_APP_PRIVATE_KEY is not set", async () => {
+    process.env.GH_APP_ID = "123";
+    delete process.env.GH_APP_PRIVATE_KEY;
+
+    await ensureAppToken();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("fetches installations and creates tokens", async () => {
+    const keyPair = await crypto.subtle.generateKey(
+      {
+        name: "RSASSA-PKCS1-v1_5",
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      true,
+      ["sign", "verify"],
+    );
+    const pkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+    const pem = `-----BEGIN PRIVATE KEY-----\n${btoa(String.fromCharCode(...new Uint8Array(pkcs8)))}\n-----END PRIVATE KEY-----`;
+
+    process.env.GH_APP_ID = "99";
+    process.env.GH_APP_PRIVATE_KEY = pem;
+
+    const expiresAt = new Date(Date.now() + 3600_000).toISOString();
+
+    fetchSpy.mockImplementation(async (url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes("/app/installations") && !urlStr.includes("/access_tokens")) {
+        return new Response(JSON.stringify([{ id: 42 }]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (urlStr.includes("/access_tokens")) {
+        return new Response(
+          JSON.stringify({ token: "ghs_installtoken123456", expires_at: expiresAt }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      // validate call
+      return mockResponse(200, rateLimitHeaders(4500, 5000));
+    });
+
+    await ensureAppToken();
+
+    const appToken = ghTokens.find((t) => t._app);
+    expect(appToken).toBeDefined();
+    expect(appToken!._appInstallationId).toBe("42");
+    expect(appToken!.valid).toBe(true);
+  });
+
+  it("updates existing app token instead of creating new one", async () => {
+    const keyPair = await crypto.subtle.generateKey(
+      {
+        name: "RSASSA-PKCS1-v1_5",
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      true,
+      ["sign", "verify"],
+    );
+    const pkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+    const pem = `-----BEGIN PRIVATE KEY-----\n${btoa(String.fromCharCode(...new Uint8Array(pkcs8)))}\n-----END PRIVATE KEY-----`;
+
+    process.env.GH_APP_ID = "99";
+    process.env.GH_APP_PRIVATE_KEY = pem;
+
+    // Pre-existing app token for installation 42
+    const existing = new GHToken("old-token", { app: true, appInstallationId: "42" });
+    existing.valid = true;
+    existing.remaining = 100;
+    ghTokens.push(existing);
+
+    const expiresAt = new Date(Date.now() + 3600_000).toISOString();
+
+    fetchSpy.mockImplementation(async (url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes("/app/installations") && !urlStr.includes("/access_tokens")) {
+        return new Response(JSON.stringify([{ id: 42 }]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (urlStr.includes("/access_tokens")) {
+        return new Response(
+          JSON.stringify({ token: "ghs_newtoken123456789", expires_at: expiresAt }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return mockResponse(200, rateLimitHeaders(4500, 5000));
+    });
+
+    await ensureAppToken();
+
+    // Should have updated the existing token, not added a new one
+    const appTokens = ghTokens.filter((t) => t._appInstallationId === "42");
+    expect(appTokens).toHaveLength(1);
+    expect(appTokens[0]!.token).toBe("ghs_newtoken123456789");
+  });
+
+  it("handles installation token fetch failure gracefully", async () => {
+    const keyPair = await crypto.subtle.generateKey(
+      {
+        name: "RSASSA-PKCS1-v1_5",
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      true,
+      ["sign", "verify"],
+    );
+    const pkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+    const pem = `-----BEGIN PRIVATE KEY-----\n${btoa(String.fromCharCode(...new Uint8Array(pkcs8)))}\n-----END PRIVATE KEY-----`;
+
+    process.env.GH_APP_ID = "99";
+    process.env.GH_APP_PRIVATE_KEY = pem;
+
+    fetchSpy.mockImplementation(async (url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes("/app/installations") && !urlStr.includes("/access_tokens")) {
+        return new Response(JSON.stringify([{ id: 42 }]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (urlStr.includes("/access_tokens")) {
+        return new Response(null, { status: 500 });
+      }
+      return mockResponse(200, rateLimitHeaders(4500, 5000));
+    });
+
+    // Should not throw
+    await ensureAppToken();
+    expect(ghTokens.filter((t) => t._app)).toHaveLength(0);
+  });
+
+  it("handles installations fetch failure gracefully", async () => {
+    const keyPair = await crypto.subtle.generateKey(
+      {
+        name: "RSASSA-PKCS1-v1_5",
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      true,
+      ["sign", "verify"],
+    );
+    const pkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+    const pem = `-----BEGIN PRIVATE KEY-----\n${btoa(String.fromCharCode(...new Uint8Array(pkcs8)))}\n-----END PRIVATE KEY-----`;
+
+    process.env.GH_APP_ID = "99";
+    process.env.GH_APP_PRIVATE_KEY = pem;
+
+    fetchSpy.mockImplementation(async (url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes("/app/installations")) {
+        return new Response(null, { status: 403 });
+      }
+      return mockResponse(200, rateLimitHeaders(4500, 5000));
+    });
+
+    // Should not throw
+    await ensureAppToken();
+  });
+
+  it("handles empty installations list", async () => {
+    const keyPair = await crypto.subtle.generateKey(
+      {
+        name: "RSASSA-PKCS1-v1_5",
+        modulusLength: 2048,
+        publicExponent: new Uint8Array([1, 0, 1]),
+        hash: "SHA-256",
+      },
+      true,
+      ["sign", "verify"],
+    );
+    const pkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+    const pem = `-----BEGIN PRIVATE KEY-----\n${btoa(String.fromCharCode(...new Uint8Array(pkcs8)))}\n-----END PRIVATE KEY-----`;
+
+    process.env.GH_APP_ID = "99";
+    process.env.GH_APP_PRIVATE_KEY = pem;
+
+    fetchSpy.mockImplementation(async (url: string | URL | Request) => {
+      const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
+      if (urlStr.includes("/app/installations")) {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return mockResponse(200, rateLimitHeaders(4500, 5000));
+    });
+
+    await ensureAppToken();
+    expect(ghTokens.filter((t) => t._app)).toHaveLength(0);
   });
 });

--- a/test/github_token.test.ts
+++ b/test/github_token.test.ts
@@ -132,8 +132,12 @@ describe("GHToken", () => {
 
   describe("validate", () => {
     let fetchSpy: ReturnType<typeof vi.spyOn>;
-    beforeEach(() => { fetchSpy = vi.spyOn(globalThis, "fetch"); });
-    afterEach(() => { fetchSpy.mockRestore(); });
+    beforeEach(() => {
+      fetchSpy = vi.spyOn(globalThis, "fetch");
+    });
+    afterEach(() => {
+      fetchSpy.mockRestore();
+    });
 
     it("updates status from /meta response", async () => {
       const resetEpoch = Math.floor(Date.now() / 1000) + 3600;
@@ -190,9 +194,24 @@ describe("GHToken", () => {
     it.each([
       { desc: "never validated", lastValidated: undefined, reset: undefined, expected: true },
       { desc: "recently validated", lastValidated: now - 1000, reset: undefined, expected: false },
-      { desc: "validated >1min ago", lastValidated: now - 61_000, reset: undefined, expected: true },
-      { desc: "stale but reset pending", lastValidated: now - 120_000, reset: now + 60_000, expected: false },
-      { desc: "stale and reset passed", lastValidated: now - 120_000, reset: now - 1000, expected: true },
+      {
+        desc: "validated >1min ago",
+        lastValidated: now - 61_000,
+        reset: undefined,
+        expected: true,
+      },
+      {
+        desc: "stale but reset pending",
+        lastValidated: now - 120_000,
+        reset: now + 60_000,
+        expected: false,
+      },
+      {
+        desc: "stale and reset passed",
+        lastValidated: now - 120_000,
+        reset: now - 1000,
+        expected: true,
+      },
     ])("$desc → $expected", ({ lastValidated, reset, expected }) => {
       const token = new GHToken("t");
       token._lastValidated = lastValidated;
@@ -209,11 +228,31 @@ describe("GHToken", () => {
       state: { valid?: boolean; remaining: number; limit: number; reset: number };
       clears: boolean;
     }>([
-      { desc: "valid=true, remaining=0, reset expired", state: { valid: true, remaining: 0, limit: 5000, reset: now - 1000 }, clears: true },
-      { desc: "valid=undefined, remaining=0, reset expired", state: { valid: undefined, remaining: 0, limit: 5000, reset: now - 1000 }, clears: true },
-      { desc: "valid=true, remaining=0, reset in future", state: { valid: true, remaining: 0, limit: 5000, reset: now + 60_000 }, clears: false },
-      { desc: "valid=true, remaining>0, reset expired", state: { valid: true, remaining: 100, limit: 5000, reset: now - 1000 }, clears: false },
-      { desc: "valid=false, remaining=0, reset expired", state: { valid: false, remaining: 0, limit: 5000, reset: now - 1000 }, clears: false },
+      {
+        desc: "valid=true, remaining=0, reset expired",
+        state: { valid: true, remaining: 0, limit: 5000, reset: now - 1000 },
+        clears: true,
+      },
+      {
+        desc: "valid=undefined, remaining=0, reset expired",
+        state: { valid: undefined, remaining: 0, limit: 5000, reset: now - 1000 },
+        clears: true,
+      },
+      {
+        desc: "valid=true, remaining=0, reset in future",
+        state: { valid: true, remaining: 0, limit: 5000, reset: now + 60_000 },
+        clears: false,
+      },
+      {
+        desc: "valid=true, remaining>0, reset expired",
+        state: { valid: true, remaining: 100, limit: 5000, reset: now - 1000 },
+        clears: false,
+      },
+      {
+        desc: "valid=false, remaining=0, reset expired",
+        state: { valid: false, remaining: 0, limit: 5000, reset: now - 1000 },
+        clears: false,
+      },
     ])("$desc → clears=$clears", ({ state, clears }) => {
       const token = new GHToken("t");
       token.valid = state.valid;
@@ -239,7 +278,12 @@ describe("GHToken", () => {
       { desc: "invalid with remaining", valid: false as const, remaining: 100, expected: false },
       { desc: "valid but exhausted", valid: true, remaining: 0, expected: false },
       { desc: "unvalidated (undefined)", valid: undefined, remaining: undefined, expected: false },
-      { desc: "valid, remaining undefined (defaults to 1)", valid: true, remaining: undefined, expected: true },
+      {
+        desc: "valid, remaining undefined (defaults to 1)",
+        valid: true,
+        remaining: undefined,
+        expected: true,
+      },
     ])("$desc → $expected", ({ valid, remaining, expected }) => {
       const token = new GHToken("t");
       token.valid = valid;
@@ -282,7 +326,9 @@ describe("GHToken", () => {
 
     it("toString includes type", () => {
       expect(new GHToken("ghp_abcdefghijklmnop").toString()).toBe("[GitHub pat token ghp_***mnop]");
-      expect(new GHToken("ghs_abcdefghijklmnop", { app: true }).toString()).toBe("[GitHub app token ghs_***mnop]");
+      expect(new GHToken("ghs_abcdefghijklmnop", { app: true }).toString()).toBe(
+        "[GitHub app token ghs_***mnop]",
+      );
     });
 
     it("toJSON returns serializable object", () => {
@@ -358,11 +404,19 @@ async function verifyJWTSignature(jwt: string, publicKey: CryptoKey) {
 function extractPkcs1FromPkcs8(pkcs8Der: ArrayBuffer): Uint8Array {
   const bytes = new Uint8Array(pkcs8Der);
   let offset = 1; // skip SEQUENCE tag
-  if (bytes[offset]! & 0x80) { offset += 1 + (bytes[offset]! & 0x7f); } else { offset += 1; }
+  if (bytes[offset]! & 0x80) {
+    offset += 1 + (bytes[offset]! & 0x7f);
+  } else {
+    offset += 1;
+  }
   offset += 3; // version INTEGER (02 01 00)
   offset += 15; // algorithmId SEQUENCE
   offset += 1; // OCTET STRING tag
-  if (bytes[offset]! & 0x80) { offset += 1 + (bytes[offset]! & 0x7f); } else { offset += 1; }
+  if (bytes[offset]! & 0x80) {
+    offset += 1 + (bytes[offset]! & 0x7f);
+  } else {
+    offset += 1;
+  }
   return bytes.slice(offset);
 }
 
@@ -416,7 +470,9 @@ describe("_createAppJWT", () => {
 // --- Token registry functions ---
 
 describe("getGHToken", () => {
-  beforeEach(() => { ghTokens.length = 0; });
+  beforeEach(() => {
+    ghTokens.length = 0;
+  });
 
   it("returns the token with highest remaining quota", () => {
     const t1 = new GHToken("tok1");
@@ -470,7 +526,9 @@ describe("ensureTokensValidated", () => {
     ghTokens.length = 0;
     ensureTokensValidated.reset();
   });
-  afterEach(() => { fetchSpy.mockRestore(); });
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
 
   it("validates tokens until one is available", async () => {
     ghTokens.push(new GHToken("tok1"), new GHToken("tok2"));
@@ -502,7 +560,9 @@ describe("ensureAllTokensValidated", () => {
     ghTokens.length = 0;
     ensureAppToken.reset();
   });
-  afterEach(() => { fetchSpy.mockRestore(); });
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
 
   it("validates all tokens", async () => {
     ghTokens.push(new GHToken("tok1"), new GHToken("tok2"));
@@ -520,7 +580,9 @@ describe("revalidateGHTokens", () => {
     fetchSpy = vi.spyOn(globalThis, "fetch");
     ghTokens.length = 0;
   });
-  afterEach(() => { fetchSpy.mockRestore(); });
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
 
   it("revalidates stale tokens", async () => {
     const t = new GHToken("tok");
@@ -561,7 +623,9 @@ describe("acquireGHToken", () => {
     ghTokens.length = 0;
     ensureTokensValidated.reset();
   });
-  afterEach(() => { fetchSpy.mockRestore(); });
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
 
   it("returns the best available token after validation", async () => {
     const t = new GHToken("tok");
@@ -614,8 +678,10 @@ describe("ensureAppToken (_refreshAppToken)", () => {
     { desc: "GH_APP_PRIVATE_KEY missing", id: "123", key: undefined },
     { desc: "both missing", id: undefined, key: undefined },
   ])("does nothing when $desc", async ({ id, key }) => {
-    if (id) process.env.GH_APP_ID = id; else delete process.env.GH_APP_ID;
-    if (key) process.env.GH_APP_PRIVATE_KEY = key; else delete process.env.GH_APP_PRIVATE_KEY;
+    if (id) process.env.GH_APP_ID = id;
+    else delete process.env.GH_APP_ID;
+    if (key) process.env.GH_APP_PRIVATE_KEY = key;
+    else delete process.env.GH_APP_PRIVATE_KEY;
     await ensureAppToken();
     expect(fetchSpy).not.toHaveBeenCalled();
   });

--- a/test/github_token.test.ts
+++ b/test/github_token.test.ts
@@ -544,7 +544,6 @@ describe("ensureAllTokensValidated", () => {
   beforeEach(() => {
     fetchSpy = vi.spyOn(globalThis, "fetch");
     ghTokens.length = 0;
-    ensureAllTokensValidated.reset();
     ensureAppToken.reset();
   });
 

--- a/utils/github.ts
+++ b/utils/github.ts
@@ -1,16 +1,7 @@
 import { defineCachedFunction } from "nitro/cache";
 import type { CacheOptions } from "nitro/types";
-import { ofetch, type FetchOptions } from "ofetch";
 import { HTTPError } from "nitro/h3";
-import {
-  GHToken,
-  ghTokens,
-  acquireGHToken,
-  formatDuration,
-  ensureAllTokensValidated,
-} from "~/utils/github_token";
-
-export { GHToken, ghTokens, ensureAllTokensValidated, formatDuration };
+import { ghTokens, acquireGHToken, formatDuration } from "~/utils/github_token";
 
 const commonCacheOptions: CacheOptions = {
   group: "gh",
@@ -25,7 +16,7 @@ const cacheOptions = (name: string): CacheOptions => ({
 });
 
 export const ghFetch = defineCachedFunction(
-  async <T = any>(url: string, opts: FetchOptions = {}) => {
+  async <T = any>(url: string, opts: RequestInit = {}) => {
     const token = await acquireGHToken();
     if (!token) {
       const soonestReset = ghTokens
@@ -34,30 +25,35 @@ export const ghFetch = defineCachedFunction(
       const resetInfo = soonestReset?.reset
         ? ` Rate limit resets in ${formatDuration(soonestReset.reset - Date.now())}.`
         : "";
-      const invalidCount = ghTokens.filter((t) => !t.valid).length;
+      const invalidCount = ghTokens.filter((t) => t.valid === false).length;
       const exhaustedCount = ghTokens.filter((t) => t.valid && (t.remaining || 0) === 0).length;
       throw new HTTPError({
         message: `No valid GitHub token available (${ghTokens.length} configured: ${invalidCount} invalid, ${exhaustedCount} rate-limited).${resetInfo}`,
         statusCode: 403,
       });
     }
-    return ofetch<T>(url, {
-      baseURL: "https://api.github.com",
-      ...(opts as any),
-      method: (opts.method || "GET").toUpperCase() as any,
+    const fullUrl = url.startsWith("/") ? url : `/${url}`;
+    const res = await fetch(`https://api.github.com${fullUrl}`, {
+      ...opts,
+      method: (opts.method || "GET").toUpperCase(),
       headers: {
         "User-Agent": "fetch",
         Authorization: `token ${token.token}`,
         ...opts.headers,
       },
-      onResponse({ response }) {
-        token.updateStatus(response);
-      },
     });
+    token.updateStatus(res);
+    if (!res.ok) {
+      throw new HTTPError({
+        message: `GitHub API error: ${res.status} ${res.statusText}`,
+        statusCode: res.status,
+      });
+    }
+    const contentType = res.headers.get("content-type") || "";
+    return (contentType.includes("application/json") ? await res.json() : await res.text()) as T;
   },
   {
     ...cacheOptions("api"),
-    integrity: "cb2RkuNE4G",
     validate(entry) {
       if (
         !entry.value ||
@@ -93,7 +89,6 @@ export const ghMarkdown = defineCachedFunction(
       method: "POST",
       headers: {
         accept: "application/vnd.github+json",
-        "content-type": "text/x-markdown",
       },
       body: JSON.stringify({
         text: markdown,

--- a/utils/github.ts
+++ b/utils/github.ts
@@ -60,6 +60,9 @@ export const ghFetch = defineCachedFunction(
       onResponse({ response }) {
         updateTokenStatus(token, response);
       },
+      onResponseError() {
+        revalidateGHTokens();
+      },
     });
   },
   {

--- a/utils/github.ts
+++ b/utils/github.ts
@@ -3,18 +3,15 @@ import type { CacheOptions } from "nitro/types";
 import { ofetch, type FetchOptions } from "ofetch";
 import { HTTPError } from "nitro/h3";
 import {
-  type GHToken,
+  GHToken,
   ghTokens,
   getGHToken,
-  updateTokenStatus,
   formatDuration,
-  ensureTokens,
   ensureTokensValidated,
   revalidateGHTokens,
 } from "~/utils/github_token";
 
-export type { GHToken };
-export { ghTokens, ensureTokens, ensureTokensValidated, formatDuration };
+export { GHToken, ghTokens, ensureTokensValidated, formatDuration };
 
 const commonCacheOptions: CacheOptions = {
   group: "gh",
@@ -58,7 +55,7 @@ export const ghFetch = defineCachedFunction(
         ...opts.headers,
       },
       onResponse({ response }) {
-        updateTokenStatus(token, response);
+        token.updateStatus(response);
       },
     });
   },

--- a/utils/github.ts
+++ b/utils/github.ts
@@ -5,14 +5,12 @@ import { HTTPError } from "nitro/h3";
 import {
   GHToken,
   ghTokens,
-  getGHToken,
+  acquireGHToken,
   formatDuration,
-  ensureTokensValidated,
   ensureAllTokensValidated,
-  revalidateGHTokens,
 } from "~/utils/github_token";
 
-export { GHToken, ghTokens, ensureTokensValidated, ensureAllTokensValidated, formatDuration };
+export { GHToken, ghTokens, ensureAllTokensValidated, formatDuration };
 
 const commonCacheOptions: CacheOptions = {
   group: "gh",
@@ -28,10 +26,7 @@ const cacheOptions = (name: string): CacheOptions => ({
 
 export const ghFetch = defineCachedFunction(
   async <T = any>(url: string, opts: FetchOptions = {}) => {
-    let token = getGHToken();
-    if (!token && (await revalidateGHTokens())) {
-      token = getGHToken();
-    }
+    const token = await acquireGHToken();
     if (!token) {
       const soonestReset = ghTokens
         .filter((t) => t.valid && t.reset)

--- a/utils/github.ts
+++ b/utils/github.ts
@@ -8,10 +8,11 @@ import {
   getGHToken,
   formatDuration,
   ensureTokensValidated,
+  ensureAllTokensValidated,
   revalidateGHTokens,
 } from "~/utils/github_token";
 
-export { GHToken, ghTokens, ensureTokensValidated, formatDuration };
+export { GHToken, ghTokens, ensureTokensValidated, ensureAllTokensValidated, formatDuration };
 
 const commonCacheOptions: CacheOptions = {
   group: "gh",

--- a/utils/github.ts
+++ b/utils/github.ts
@@ -6,11 +6,11 @@ import {
   type GHToken,
   ghTokens,
   getGHToken,
-  validateGHTokens,
   updateTokenStatus,
   formatDuration,
   ensureTokens,
   ensureTokensValidated,
+  revalidateGHTokens,
 } from "~/utils/github_token";
 
 export type { GHToken };
@@ -31,8 +31,7 @@ const cacheOptions = (name: string): CacheOptions => ({
 export const ghFetch = defineCachedFunction(
   async <T = any>(url: string, opts: FetchOptions = {}) => {
     let token = getGHToken();
-    if (!token) {
-      await ensureTokensValidated();
+    if (!token && (await revalidateGHTokens())) {
       token = getGHToken();
     }
     if (!token) {
@@ -49,23 +48,19 @@ export const ghFetch = defineCachedFunction(
         statusCode: 403,
       });
     }
-    const res = await ofetch
-      .raw<T>(url, {
-        baseURL: "https://api.github.com",
-        ...(opts as any),
-        method: (opts.method || "GET").toUpperCase() as any,
-        headers: {
-          "User-Agent": "fetch",
-          Authorization: `token ${token.token}`,
-          ...opts.headers,
-        },
-      })
-      .catch(async (error: unknown) => {
-        await validateGHTokens().catch(() => {});
-        throw error;
-      });
-    updateTokenStatus(token, res);
-    return res._data as T;
+    return ofetch<T>(url, {
+      baseURL: "https://api.github.com",
+      ...(opts as any),
+      method: (opts.method || "GET").toUpperCase() as any,
+      headers: {
+        "User-Agent": "fetch",
+        Authorization: `token ${token.token}`,
+        ...opts.headers,
+      },
+      onResponse({ response }) {
+        updateTokenStatus(token, response);
+      },
+    });
   },
   {
     ...cacheOptions("api"),

--- a/utils/github.ts
+++ b/utils/github.ts
@@ -60,9 +60,6 @@ export const ghFetch = defineCachedFunction(
       onResponse({ response }) {
         updateTokenStatus(token, response);
       },
-      onResponseError() {
-        revalidateGHTokens();
-      },
     });
   },
   {

--- a/utils/github_token.ts
+++ b/utils/github_token.ts
@@ -3,6 +3,7 @@ import { ofetch } from "ofetch";
 
 const REVALIDATE_INTERVAL = 60_000; // 1 min
 
+/** Represents a GitHub API token with rate limit tracking and validation. */
 export class GHToken {
   token: string;
   valid?: boolean;
@@ -76,6 +77,7 @@ export class GHToken {
 
 const runtimeConfig = useRuntimeConfig();
 
+/** All registered GitHub tokens (PAT and App-generated). */
 export const ghTokens: GHToken[] = ((runtimeConfig.GH_TOKEN as string) || "")
   .split(",")
   .map((t) => t.trim())
@@ -84,11 +86,12 @@ export const ghTokens: GHToken[] = ((runtimeConfig.GH_TOKEN as string) || "")
 
 let _validatePromise: Promise<void> | undefined;
 
+/** Validates all tokens and bootstraps App tokens on first call. Idempotent. */
 export async function ensureTokensValidated() {
   if (!_validatePromise) {
     _validatePromise = Promise.all([
       Promise.all(ghTokens.map((t) => t.validate())),
-      _ensureAppToken(),
+      ensureAppToken(),
     ]).then(() => {});
   }
   await _validatePromise;
@@ -115,13 +118,17 @@ export function revalidateGHTokens() {
 async function _doRevalidateGHTokens() {
   const now = Date.now();
   const staleTokens = ghTokens.filter((t) => t.isStale(now));
-  if (staleTokens.length === 0) {
+  if (staleTokens.length === 0 && getGHToken()) {
     return false;
   }
-  await Promise.all(staleTokens.map((t) => t.validate()));
+  await Promise.all([
+    ...staleTokens.map((t) => t.validate()),
+    ensureAppToken(),
+  ]);
   return true;
 }
 
+/** Returns the best available token (highest remaining quota), or `undefined` if none available. */
 export function getGHToken() {
   const now = Date.now();
   for (const token of ghTokens) {
@@ -132,6 +139,7 @@ export function getGHToken() {
     .sort((a, b) => (b.remaining ?? 1) - (a.remaining ?? 1))[0];
 }
 
+/** Formats a duration in milliseconds to a human-readable string (e.g. `"5m"`, `"1h30m"`). */
 export function formatDuration(ms: number) {
   const minutes = Math.round(ms / 60_000);
   if (minutes < 1) return "<1m";
@@ -145,7 +153,8 @@ export function formatDuration(ms: number) {
 
 let _appTokenPromise: Promise<void> | undefined;
 
-function _ensureAppToken() {
+/** Bootstraps GitHub App installation tokens if App credentials are configured. Idempotent. */
+export function ensureAppToken() {
   if (!_appTokenPromise) {
     _appTokenPromise = _refreshAppToken();
   }
@@ -241,6 +250,7 @@ async function _refreshAppToken() {
   }
 }
 
+/** Creates an RS256-signed JWT for GitHub App authentication. Exported for testing. */
 export async function _createAppJWT(appId: string, privateKey: string): Promise<string> {
   const now = Math.floor(Date.now() / 1000);
   const header = _base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
@@ -261,6 +271,7 @@ export async function _createAppJWT(appId: string, privateKey: string): Promise<
   return `${header}.${payload}.${signature}`;
 }
 
+/** Encodes a UTF-8 string to base64url. Exported for testing. */
 export function _base64url(str: string): string {
   return _bufferToBase64url(new TextEncoder().encode(str));
 }

--- a/utils/github_token.ts
+++ b/utils/github_token.ts
@@ -86,16 +86,61 @@ export const ghTokens: GHToken[] = ((runtimeConfig.GH_TOKEN as string) || "")
 
 let _validatePromise: Promise<void> | undefined;
 
-/** Validates all tokens and bootstraps App tokens on first call. Idempotent. */
-export async function ensureTokensValidated() {
-  if (!_validatePromise) {
-    _validatePromise = Promise.all([
+/** Validates all tokens and bootstraps App tokens. Use for status page. Idempotent. */
+export async function ensureAllTokensValidated() {
+  if (!_validateAllPromise) {
+    _validateAllPromise = Promise.all([
       Promise.all(ghTokens.map((t) => t.validate())),
       ensureAppToken(),
     ]).then(() => {});
   }
-  await _validatePromise;
+  await _validateAllPromise;
   await revalidateGHTokens();
+}
+
+let _validateAllPromise: Promise<void> | undefined;
+
+/** Validates tokens until one is available, then continues the rest in background. Idempotent. */
+export async function ensureTokensValidated() {
+  if (!_validatePromise) {
+    _validatePromise = _validateUntilOneAvailable();
+  }
+  await _validatePromise;
+  if (!getGHToken()) {
+    await revalidateGHTokens();
+  }
+}
+
+async function _validateUntilOneAvailable() {
+  // Race PAT validations and App token bootstrap — resolve as soon as any token is available
+  const patCount = ghTokens.length;
+  const hasAppConfig = !!(runtimeConfig.GH_APP_ID && runtimeConfig.GH_APP_PRIVATE_KEY);
+  const totalTasks = patCount + (hasAppConfig ? 1 : 0);
+
+  if (totalTasks === 0) return;
+
+  await new Promise<void>((resolve) => {
+    let resolved = false;
+    let pending = totalTasks;
+
+    const tryResolve = () => {
+      if (!resolved && getGHToken()) {
+        resolved = true;
+        resolve();
+      }
+      if (--pending === 0 && !resolved) {
+        resolve(); // All done, none available
+      }
+    };
+
+    for (const token of ghTokens) {
+      token.validate().then(tryResolve);
+    }
+
+    if (hasAppConfig) {
+      ensureAppToken().then(tryResolve);
+    }
+  });
 }
 
 let _revalidatePromise: Promise<boolean> | undefined;

--- a/utils/github_token.ts
+++ b/utils/github_token.ts
@@ -121,10 +121,7 @@ async function _doRevalidateGHTokens() {
   if (staleTokens.length === 0 && getGHToken()) {
     return false;
   }
-  await Promise.all([
-    ...staleTokens.map((t) => t.validate()),
-    ensureAppToken(),
-  ]);
+  await Promise.all([...staleTokens.map((t) => t.validate()), ensureAppToken()]);
   return true;
 }
 

--- a/utils/github_token.ts
+++ b/utils/github_token.ts
@@ -15,6 +15,7 @@ export const ghTokens: GHToken[] = [];
 
 let _tokensInitialized = false;
 let _tokensValidatePromise: Promise<void> | undefined;
+let _tokensLastValidatedDate: Date | undefined;
 
 export function ensureTokens() {
   if (_tokensInitialized) return;
@@ -35,8 +36,11 @@ export function ensureTokensValidated() {
   return _tokensValidatePromise;
 }
 
-export async function validateGHTokens() {
+// NOTE: This function consumes one API call for each token to get their rate limit info.
+// Call this sparingly.
+async function validateGHTokens() {
   ensureTokens();
+  _tokensLastValidatedDate = new Date();
   await Promise.all(
     ghTokens.map(async (token) => {
       try {
@@ -63,6 +67,18 @@ export async function validateGHTokens() {
       }
     }),
   );
+}
+
+/**
+ * Calls `validateGHTokens()` only after at least 1 min has elapsed to not bombard the GitHub API
+ * when we run out of tokens.
+ */
+export async function revalidateGHTokens() {
+  if (!_tokensLastValidatedDate || Date.now() - _tokensLastValidatedDate.getTime() > 60_000) {
+    await validateGHTokens();
+    return true;
+  }
+  return false;
 }
 
 export function getGHToken() {

--- a/utils/github_token.ts
+++ b/utils/github_token.ts
@@ -55,11 +55,8 @@ async function validateGHToken(token: GHToken) {
       `GitHub token ${token.valid ? "validated" : "invalid"} (${res.status}): ${token.remaining}/${token.limit}${resource ? ` [${resource}]` : ""}${resetInfo}`,
     );
   } catch (error) {
+    // Preserve last-known token state on transport errors (DNS/TLS/timeout)
     console.error("Error validating GitHub token:", error);
-    token.valid = false;
-    token.remaining = 0;
-    token.limit = 0;
-    token._lastValidated = Date.now();
   }
 }
 
@@ -70,11 +67,24 @@ async function validateGHTokens() {
 
 const REVALIDATE_INTERVAL = 60_000; // 1 min
 
+let _revalidatePromise: Promise<boolean> | undefined;
+
 /**
  * Revalidates only tokens that haven't been validated in the last minute.
+ * Concurrent callers share the same in-flight promise.
  * Returns true if any tokens were revalidated.
  */
-export async function revalidateGHTokens() {
+export function revalidateGHTokens() {
+  if (_revalidatePromise) {
+    return _revalidatePromise;
+  }
+  _revalidatePromise = _doRevalidateGHTokens().finally(() => {
+    _revalidatePromise = undefined;
+  });
+  return _revalidatePromise;
+}
+
+async function _doRevalidateGHTokens() {
   ensureTokens();
   const now = Date.now();
   const staleTokens = ghTokens.filter(

--- a/utils/github_token.ts
+++ b/utils/github_token.ts
@@ -88,7 +88,9 @@ async function _doRevalidateGHTokens() {
   ensureTokens();
   const now = Date.now();
   const staleTokens = ghTokens.filter(
-    (t) => !t._lastValidated || now - t._lastValidated > REVALIDATE_INTERVAL,
+    (t) =>
+      (!t._lastValidated || now - t._lastValidated > REVALIDATE_INTERVAL) &&
+      (!t.reset || t.reset <= now),
   );
   if (staleTokens.length === 0) {
     return false;

--- a/utils/github_token.ts
+++ b/utils/github_token.ts
@@ -7,6 +7,7 @@ export interface GHToken {
   remaining?: number;
   limit?: number;
   reset?: number;
+  _lastValidated?: number;
   _app?: boolean;
   _appInstallationId?: string;
 }
@@ -15,7 +16,6 @@ export const ghTokens: GHToken[] = [];
 
 let _tokensInitialized = false;
 let _tokensValidatePromise: Promise<void> | undefined;
-let _tokensLastValidatedDate: Date | undefined;
 
 export function ensureTokens() {
   if (_tokensInitialized) return;
@@ -36,49 +36,55 @@ export function ensureTokensValidated() {
   return _tokensValidatePromise;
 }
 
-// NOTE: This function consumes one API call for each token to get their rate limit info.
+// NOTE: Each call consumes one API request per token to fetch rate limit info.
 // Call this sparingly.
-async function validateGHTokens() {
-  ensureTokens();
-  _tokensLastValidatedDate = new Date();
-  await Promise.all(
-    ghTokens.map(async (token) => {
-      try {
-        const res = await ofetch.raw("https://api.github.com/meta", {
-          ignoreResponseError: true,
-          headers: {
-            "User-Agent": "fetch",
-            Authorization: `token ${token.token}`,
-          },
-        });
-        updateTokenStatus(token, res);
-        const resetInfo = token.reset
-          ? ` resets in ${formatDuration(token.reset - Date.now())}`
-          : "";
-        const resource = res.headers.get("x-ratelimit-resource") || "";
-        console.log(
-          `GitHub token ${token.valid ? "validated" : "invalid"} (${res.status}): ${token.remaining}/${token.limit}${resource ? ` [${resource}]` : ""}${resetInfo}`,
-        );
-      } catch (error) {
-        console.error("Error validating GitHub token:", error);
-        token.valid = false;
-        token.remaining = 0;
-        token.limit = 0;
-      }
-    }),
-  );
+async function validateGHToken(token: GHToken) {
+  try {
+    const res = await ofetch.raw("https://api.github.com/meta", {
+      ignoreResponseError: true,
+      headers: {
+        "User-Agent": "fetch",
+        Authorization: `token ${token.token}`,
+      },
+    });
+    updateTokenStatus(token, res);
+    token._lastValidated = Date.now();
+    const resetInfo = token.reset ? ` resets in ${formatDuration(token.reset - Date.now())}` : "";
+    const resource = res.headers.get("x-ratelimit-resource") || "";
+    console.log(
+      `GitHub token ${token.valid ? "validated" : "invalid"} (${res.status}): ${token.remaining}/${token.limit}${resource ? ` [${resource}]` : ""}${resetInfo}`,
+    );
+  } catch (error) {
+    console.error("Error validating GitHub token:", error);
+    token.valid = false;
+    token.remaining = 0;
+    token.limit = 0;
+    token._lastValidated = Date.now();
+  }
 }
 
+async function validateGHTokens() {
+  ensureTokens();
+  await Promise.all(ghTokens.map((token) => validateGHToken(token)));
+}
+
+const REVALIDATE_INTERVAL = 60_000; // 1 min
+
 /**
- * Calls `validateGHTokens()` only after at least 1 min has elapsed to not bombard the GitHub API
- * when we run out of tokens.
+ * Revalidates only tokens that haven't been validated in the last minute.
+ * Returns true if any tokens were revalidated.
  */
 export async function revalidateGHTokens() {
-  if (!_tokensLastValidatedDate || Date.now() - _tokensLastValidatedDate.getTime() > 60_000) {
-    await validateGHTokens();
-    return true;
+  ensureTokens();
+  const now = Date.now();
+  const staleTokens = ghTokens.filter(
+    (t) => !t._lastValidated || now - t._lastValidated > REVALIDATE_INTERVAL,
+  );
+  if (staleTokens.length === 0) {
+    return false;
   }
-  return false;
+  await Promise.all(staleTokens.map((token) => validateGHToken(token)));
+  return true;
 }
 
 export function getGHToken() {

--- a/utils/github_token.ts
+++ b/utils/github_token.ts
@@ -28,7 +28,7 @@ export class GHToken {
     this.reset = resetEpoch ? Number.parseInt(resetEpoch) * 1000 : undefined;
   }
 
-  // NOTE: Each call consumes one API request to fetch rate limit info.
+  /** NOTE: Each call consumes one API request to fetch rate limit info. */
   async validate() {
     try {
       const res = await ofetch.raw("https://api.github.com/meta", {

--- a/utils/github_token.ts
+++ b/utils/github_token.ts
@@ -1,5 +1,3 @@
-import { ofetch } from "ofetch";
-
 const REVALIDATE_INTERVAL = 60_000; // 1 min
 
 /** Represents a GitHub API token with rate limit tracking and validation. */
@@ -21,9 +19,7 @@ export class GHToken {
   }
 
   get maskedToken() {
-    return this.token.length > 8
-      ? this.token.slice(0, 4) + "***" + this.token.slice(-4)
-      : "***";
+    return this.token.length > 8 ? this.token.slice(0, 4) + "***" + this.token.slice(-4) : "***";
   }
 
   [Symbol.for("nodejs.util.inspect.custom")]() {
@@ -46,18 +42,19 @@ export class GHToken {
   }
 
   updateStatus(res: Response) {
-    this.remaining = Number.parseInt(res.headers.get("x-ratelimit-remaining") || "0");
-    this.limit = Number.parseInt(res.headers.get("x-ratelimit-limit") || "0");
     this.valid = res.status !== 401;
+    const remaining = res.headers.get("x-ratelimit-remaining");
+    const limit = res.headers.get("x-ratelimit-limit");
     const resetEpoch = res.headers.get("x-ratelimit-reset");
-    this.reset = resetEpoch ? Number.parseInt(resetEpoch) * 1000 : undefined;
+    if (remaining) this.remaining = Number.parseInt(remaining);
+    if (limit) this.limit = Number.parseInt(limit);
+    if (resetEpoch) this.reset = Number.parseInt(resetEpoch) * 1000;
   }
 
   /** NOTE: Each call consumes one API request to fetch rate limit info. */
   async validate() {
     try {
-      const res = await ofetch.raw("https://api.github.com/meta", {
-        ignoreResponseError: true,
+      const res = await fetch("https://api.github.com/meta", {
         headers: {
           "User-Agent": "fetch",
           Authorization: `token ${this.token}`,
@@ -78,8 +75,9 @@ export class GHToken {
 
   /** Returns true if this token needs revalidation */
   isStale(now = Date.now()) {
+    if (!this._lastValidated) return true;
     if (this.reset && this.reset > now) return false;
-    return !this._lastValidated || now - this._lastValidated > REVALIDATE_INTERVAL;
+    return now - this._lastValidated > REVALIDATE_INTERVAL;
   }
 
   /** Clears expired rate limit state */
@@ -99,7 +97,6 @@ export class GHToken {
 
 // --- Token registry ---
 
-
 /** All registered GitHub tokens (PAT and App-generated). */
 export const ghTokens: GHToken[] = (process.env.GH_TOKEN || "")
   .split(",")
@@ -109,11 +106,7 @@ export const ghTokens: GHToken[] = (process.env.GH_TOKEN || "")
 
 /** Validates all tokens and bootstraps App tokens. Use for status page. Idempotent (once). */
 export const ensureAllTokensValidated = idempotent(async () => {
-  await Promise.all([
-    Promise.all(ghTokens.map((t) => t.validate())),
-    ensureAppToken(),
-  ]);
-  await revalidateGHTokens();
+  await Promise.all([Promise.all(ghTokens.map((t) => t.validate())), ensureAppToken()]);
 });
 
 /** Validates tokens until one is available, then continues the rest in background. Idempotent (once). */
@@ -125,35 +118,13 @@ export const ensureTokensValidated = idempotent(async () => {
 });
 
 async function _validateUntilOneAvailable() {
-  // Race PAT validations and App token bootstrap — resolve as soon as any token is available
-  const patCount = ghTokens.length;
-  const hasAppConfig = !!(process.env.GH_APP_ID && process.env.GH_APP_PRIVATE_KEY);
-  const totalTasks = patCount + (hasAppConfig ? 1 : 0);
-
-  if (totalTasks === 0) return;
-
-  await new Promise<void>((resolve) => {
-    let resolved = false;
-    let pending = totalTasks;
-
-    const tryResolve = () => {
-      if (!resolved && getGHToken()) {
-        resolved = true;
-        resolve();
-      }
-      if (--pending === 0 && !resolved) {
-        resolve(); // All done, none available
-      }
-    };
-
-    for (const token of ghTokens) {
-      token.validate().then(tryResolve);
-    }
-
-    if (hasAppConfig) {
-      ensureAppToken().then(tryResolve);
-    }
-  });
+  const tasks = [
+    ...ghTokens.map((t) => t.validate()),
+    ...(process.env.GH_APP_ID && process.env.GH_APP_PRIVATE_KEY ? [ensureAppToken()] : []),
+  ];
+  if (tasks.length > 0) {
+    await Promise.allSettled(tasks);
+  }
 }
 
 /**
@@ -179,19 +150,22 @@ export function getGHToken() {
   for (const token of ghTokens) {
     token.clearExpiredLimits(now);
   }
-  return ghTokens
-    .filter((t) => t.available)
-    .sort((a, b) => (b.remaining ?? 1) - (a.remaining ?? 1))[0];
+  let best: GHToken | undefined;
+  for (const t of ghTokens) {
+    if (t.available && (t.remaining ?? 1) > (best?.remaining ?? 0)) {
+      best = t;
+    }
+  }
+  return best;
 }
 
 /** Ensures tokens are validated and returns the best available one. Revalidates if needed. */
 export async function acquireGHToken(): Promise<GHToken | undefined> {
   await ensureTokensValidated();
-  let token = getGHToken();
-  if (!token && (await revalidateGHTokens())) {
-    token = getGHToken();
-  }
-  return token;
+  const token = getGHToken();
+  if (token) return token;
+  await revalidateGHTokens();
+  return getGHToken();
 }
 
 /** Formats a duration in milliseconds to a human-readable string (e.g. `"5m"`, `"1h30m"`). */
@@ -206,32 +180,32 @@ export function formatDuration(ms: number) {
 
 // --- GitHub App token ---
 
-/** Bootstraps GitHub App installation tokens if App credentials are configured. Idempotent (once). */
-export const ensureAppToken = idempotent(_refreshAppToken);
+/** Bootstraps GitHub App installation tokens if App credentials are configured. Coalesced (not once). */
+export const ensureAppToken = idempotent(_refreshAppToken, { once: false });
 
 async function _refreshAppToken() {
   try {
     const appId = process.env.GH_APP_ID;
     const privateKey = process.env.GH_APP_PRIVATE_KEY;
     if (!appId || !privateKey) {
-      ensureAppToken.reset();
       return;
     }
 
     const jwt = await _createAppJWT(appId, privateKey);
 
-    const installations = await ofetch<{ id: number }[]>(
-      "https://api.github.com/app/installations",
-      {
-        headers: {
-          Authorization: `Bearer ${jwt}`,
-          Accept: "application/vnd.github+json",
-          "User-Agent": "fetch",
-        },
+    const installationsRes = await fetch("https://api.github.com/app/installations", {
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "fetch",
       },
-    );
+    });
+    if (!installationsRes.ok) {
+      throw new Error(`Failed to fetch installations: ${installationsRes.status}`);
+    }
+    const installations: { id: number }[] = await installationsRes.json();
 
-    const installationIds = installations.map((i) => String(i.id));
+    const installationIds = installations.map((i: { id: number }) => String(i.id));
 
     if (installationIds.length === 0) {
       console.log("No GitHub App installations found");
@@ -241,9 +215,9 @@ async function _refreshAppToken() {
     let earliestRefresh = Number.POSITIVE_INFINITY;
 
     await Promise.all(
-      installationIds.map(async (installationId) => {
+      installationIds.map(async (installationId: string) => {
         try {
-          const res = await ofetch<{ token: string; expires_at: string }>(
+          const tokenRes = await fetch(
             `https://api.github.com/app/installations/${installationId}/access_tokens`,
             {
               method: "POST",
@@ -254,6 +228,10 @@ async function _refreshAppToken() {
               },
             },
           );
+          if (!tokenRes.ok) {
+            throw new Error(`Failed to create installation token: ${tokenRes.status}`);
+          }
+          const res: { token: string; expires_at: string } = await tokenRes.json();
 
           const existing = ghTokens.find((t) => t._appInstallationId === installationId);
           if (existing) {
@@ -262,13 +240,15 @@ async function _refreshAppToken() {
             existing.remaining = undefined;
             existing.limit = undefined;
             existing.reset = undefined;
+            await existing.validate();
           } else {
-            ghTokens.push(
-              new GHToken(res.token, {
-                app: true,
-                appInstallationId: installationId,
-              }),
-            );
+            const newToken = new GHToken(res.token, {
+              app: true,
+              appInstallationId: installationId,
+            });
+            newToken.valid = true;
+            ghTokens.push(newToken);
+            await newToken.validate();
           }
 
           const expiresAt = new Date(res.expires_at).getTime();
@@ -288,13 +268,9 @@ async function _refreshAppToken() {
     );
 
     if (earliestRefresh < Number.POSITIVE_INFINITY) {
-      setTimeout(() => {
-        ensureAppToken.reset();
-        ensureAppToken();
-      }, earliestRefresh);
+      setTimeout(() => ensureAppToken(), earliestRefresh);
     }
   } catch (error) {
-    ensureAppToken.reset();
     console.error("Failed to initialize GitHub App tokens:", error);
   }
 }

--- a/utils/github_token.ts
+++ b/utils/github_token.ts
@@ -1,4 +1,3 @@
-import { useRuntimeConfig } from "nitro/runtime-config";
 import { ofetch } from "ofetch";
 
 const REVALIDATE_INTERVAL = 60_000; // 1 min
@@ -19,6 +18,31 @@ export class GHToken {
     this.token = token;
     this._app = opts?.app;
     this._appInstallationId = opts?.appInstallationId;
+  }
+
+  get maskedToken() {
+    return this.token.length > 8
+      ? this.token.slice(0, 4) + "***" + this.token.slice(-4)
+      : "***";
+  }
+
+  [Symbol.for("nodejs.util.inspect.custom")]() {
+    return this.toString();
+  }
+
+  toJSON() {
+    return {
+      token: this.maskedToken,
+      valid: this.valid,
+      remaining: this.remaining,
+      limit: this.limit,
+      reset: this.reset,
+    };
+  }
+
+  toString() {
+    const type = this._app ? "app" : "pat";
+    return `[GitHub ${type} token ${this.maskedToken}]`;
   }
 
   updateStatus(res: Response) {
@@ -75,46 +99,35 @@ export class GHToken {
 
 // --- Token registry ---
 
-const runtimeConfig = useRuntimeConfig();
 
 /** All registered GitHub tokens (PAT and App-generated). */
-export const ghTokens: GHToken[] = ((runtimeConfig.GH_TOKEN as string) || "")
+export const ghTokens: GHToken[] = (process.env.GH_TOKEN || "")
   .split(",")
   .map((t) => t.trim())
   .filter(Boolean)
   .map((t) => new GHToken(t));
 
-let _validatePromise: Promise<void> | undefined;
-
-/** Validates all tokens and bootstraps App tokens. Use for status page. Idempotent. */
-export async function ensureAllTokensValidated() {
-  if (!_validateAllPromise) {
-    _validateAllPromise = Promise.all([
-      Promise.all(ghTokens.map((t) => t.validate())),
-      ensureAppToken(),
-    ]).then(() => {});
-  }
-  await _validateAllPromise;
+/** Validates all tokens and bootstraps App tokens. Use for status page. Idempotent (once). */
+export const ensureAllTokensValidated = idempotent(async () => {
+  await Promise.all([
+    Promise.all(ghTokens.map((t) => t.validate())),
+    ensureAppToken(),
+  ]);
   await revalidateGHTokens();
-}
+});
 
-let _validateAllPromise: Promise<void> | undefined;
-
-/** Validates tokens until one is available, then continues the rest in background. Idempotent. */
-export async function ensureTokensValidated() {
-  if (!_validatePromise) {
-    _validatePromise = _validateUntilOneAvailable();
-  }
-  await _validatePromise;
+/** Validates tokens until one is available, then continues the rest in background. Idempotent (once). */
+export const ensureTokensValidated = idempotent(async () => {
+  await _validateUntilOneAvailable();
   if (!getGHToken()) {
     await revalidateGHTokens();
   }
-}
+});
 
 async function _validateUntilOneAvailable() {
   // Race PAT validations and App token bootstrap — resolve as soon as any token is available
   const patCount = ghTokens.length;
-  const hasAppConfig = !!(runtimeConfig.GH_APP_ID && runtimeConfig.GH_APP_PRIVATE_KEY);
+  const hasAppConfig = !!(process.env.GH_APP_ID && process.env.GH_APP_PRIVATE_KEY);
   const totalTasks = patCount + (hasAppConfig ? 1 : 0);
 
   if (totalTasks === 0) return;
@@ -143,22 +156,12 @@ async function _validateUntilOneAvailable() {
   });
 }
 
-let _revalidatePromise: Promise<boolean> | undefined;
-
 /**
  * Revalidates only tokens that haven't been validated in the last minute.
- * Concurrent callers share the same in-flight promise.
+ * Concurrent callers share the same in-flight promise (coalesced, not once).
  * Returns true if any tokens were revalidated.
  */
-export function revalidateGHTokens() {
-  if (_revalidatePromise) {
-    return _revalidatePromise;
-  }
-  _revalidatePromise = _doRevalidateGHTokens().finally(() => {
-    _revalidatePromise = undefined;
-  });
-  return _revalidatePromise;
-}
+export const revalidateGHTokens = idempotent(_doRevalidateGHTokens, { once: false });
 
 async function _doRevalidateGHTokens() {
   const now = Date.now();
@@ -181,6 +184,16 @@ export function getGHToken() {
     .sort((a, b) => (b.remaining ?? 1) - (a.remaining ?? 1))[0];
 }
 
+/** Ensures tokens are validated and returns the best available one. Revalidates if needed. */
+export async function acquireGHToken(): Promise<GHToken | undefined> {
+  await ensureTokensValidated();
+  let token = getGHToken();
+  if (!token && (await revalidateGHTokens())) {
+    token = getGHToken();
+  }
+  return token;
+}
+
 /** Formats a duration in milliseconds to a human-readable string (e.g. `"5m"`, `"1h30m"`). */
 export function formatDuration(ms: number) {
   const minutes = Math.round(ms / 60_000);
@@ -193,22 +206,15 @@ export function formatDuration(ms: number) {
 
 // --- GitHub App token ---
 
-let _appTokenPromise: Promise<void> | undefined;
-
-/** Bootstraps GitHub App installation tokens if App credentials are configured. Idempotent. */
-export function ensureAppToken() {
-  if (!_appTokenPromise) {
-    _appTokenPromise = _refreshAppToken();
-  }
-  return _appTokenPromise;
-}
+/** Bootstraps GitHub App installation tokens if App credentials are configured. Idempotent (once). */
+export const ensureAppToken = idempotent(_refreshAppToken);
 
 async function _refreshAppToken() {
   try {
-    const appId = runtimeConfig.GH_APP_ID as string;
-    const privateKey = runtimeConfig.GH_APP_PRIVATE_KEY as string;
+    const appId = process.env.GH_APP_ID;
+    const privateKey = process.env.GH_APP_PRIVATE_KEY;
     if (!appId || !privateKey) {
-      _appTokenPromise = undefined;
+      ensureAppToken.reset();
       return;
     }
 
@@ -283,11 +289,12 @@ async function _refreshAppToken() {
 
     if (earliestRefresh < Number.POSITIVE_INFINITY) {
       setTimeout(() => {
-        _appTokenPromise = _refreshAppToken();
+        ensureAppToken.reset();
+        ensureAppToken();
       }, earliestRefresh);
     }
   } catch (error) {
-    _appTokenPromise = undefined;
+    ensureAppToken.reset();
     console.error("Failed to initialize GitHub App tokens:", error);
   }
 }
@@ -385,4 +392,32 @@ function _concat(...arrays: Uint8Array[]): Uint8Array {
     offset += a.length;
   }
   return result;
+}
+
+/**
+ * Wraps an async function so concurrent calls share a single in-flight promise.
+ *
+ * - `once: true` (default) — runs at most once; subsequent calls return the cached result.
+ * - `once: false` — concurrent calls share one execution, but after it settles a new call triggers a fresh run.
+ *
+ * Returns a callable with a `.reset()` method to clear the cached promise.
+ */
+function idempotent<T>(
+  fn: () => Promise<T>,
+  opts?: { once?: boolean },
+): (() => Promise<T>) & { reset: () => void } {
+  const once = opts?.once !== false;
+  let pending: Promise<T> | undefined;
+  const wrapped = () => {
+    if (!pending) {
+      pending = fn().finally(() => {
+        if (!once) pending = undefined;
+      });
+    }
+    return pending;
+  };
+  wrapped.reset = () => {
+    pending = undefined;
+  };
+  return wrapped;
 }

--- a/utils/github_token.ts
+++ b/utils/github_token.ts
@@ -59,7 +59,7 @@ export class GHToken {
 
   /** Clears expired rate limit state */
   clearExpiredLimits(now = Date.now()) {
-    if (this.valid && this.remaining === 0 && this.reset && this.reset < now) {
+    if (this.valid !== false && this.remaining === 0 && this.reset && this.reset < now) {
       this.remaining = undefined;
       this.limit = undefined;
       this.reset = undefined;
@@ -84,14 +84,15 @@ export const ghTokens: GHToken[] = ((runtimeConfig.GH_TOKEN as string) || "")
 
 let _validatePromise: Promise<void> | undefined;
 
-export function ensureTokensValidated() {
+export async function ensureTokensValidated() {
   if (!_validatePromise) {
     _validatePromise = Promise.all([
       Promise.all(ghTokens.map((t) => t.validate())),
       _ensureAppToken(),
     ]).then(() => {});
   }
-  return _validatePromise;
+  await _validatePromise;
+  await revalidateGHTokens();
 }
 
 let _revalidatePromise: Promise<boolean> | undefined;
@@ -156,6 +157,7 @@ async function _refreshAppToken() {
     const appId = runtimeConfig.GH_APP_ID as string;
     const privateKey = runtimeConfig.GH_APP_PRIVATE_KEY as string;
     if (!appId || !privateKey) {
+      _appTokenPromise = undefined;
       return;
     }
 
@@ -234,6 +236,7 @@ async function _refreshAppToken() {
       }, earliestRefresh);
     }
   } catch (error) {
+    _appTokenPromise = undefined;
     console.error("Failed to initialize GitHub App tokens:", error);
   }
 }

--- a/utils/github_token.ts
+++ b/utils/github_token.ts
@@ -104,10 +104,11 @@ export const ghTokens: GHToken[] = (process.env.GH_TOKEN || "")
   .filter(Boolean)
   .map((t) => new GHToken(t));
 
-/** Validates all tokens and bootstraps App tokens. Use for status page. Idempotent (once). */
-export const ensureAllTokensValidated = idempotent(async () => {
-  await Promise.all([Promise.all(ghTokens.map((t) => t.validate())), ensureAppToken()]);
-});
+/** Bootstraps all App tokens (once), then re-validates all tokens. Use for status page. */
+export async function ensureAllTokensValidated() {
+  await _ensureAllAppTokensOnce();
+  await Promise.all(ghTokens.map((t) => t.validate()));
+}
 
 /** Validates tokens until one is available, then continues the rest in background. Idempotent (once). */
 export const ensureTokensValidated = idempotent(async () => {
@@ -180,10 +181,13 @@ export function formatDuration(ms: number) {
 
 // --- GitHub App token ---
 
-/** Bootstraps GitHub App installation tokens if App credentials are configured. Coalesced (not once). */
-export const ensureAppToken = idempotent(_refreshAppToken, { once: false });
+/** Bootstraps GitHub App installation tokens (samples up to 5 random installations). Coalesced (not once). */
+export const ensureAppToken = idempotent(() => _refreshAppToken(false), { once: false });
 
-async function _refreshAppToken() {
+/** Bootstraps all GitHub App installation tokens (once). Used by the status page. */
+const _ensureAllAppTokensOnce = idempotent(() => _refreshAppToken(true));
+
+async function _refreshAppToken(all: boolean) {
   try {
     const appId = process.env.GH_APP_ID;
     const privateKey = process.env.GH_APP_PRIVATE_KEY;
@@ -205,11 +209,22 @@ async function _refreshAppToken() {
     }
     const installations: { id: number }[] = await installationsRes.json();
 
-    const installationIds = installations.map((i: { id: number }) => String(i.id));
+    let installationIds = installations.map((i: { id: number }) => String(i.id));
 
     if (installationIds.length === 0) {
       console.log("No GitHub App installations found");
       return;
+    }
+
+    // Sample up to 5 random installations unless loading all (status page)
+    if (!all && installationIds.length > 5) {
+      for (let i = installationIds.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        const tmp = installationIds[i]!;
+        installationIds[i] = installationIds[j]!;
+        installationIds[j] = tmp;
+      }
+      installationIds = installationIds.slice(0, 5);
     }
 
     let earliestRefresh = Number.POSITIVE_INFINITY;

--- a/utils/github_token.ts
+++ b/utils/github_token.ts
@@ -1,71 +1,98 @@
 import { useRuntimeConfig } from "nitro/runtime-config";
 import { ofetch } from "ofetch";
 
-export interface GHToken {
+const REVALIDATE_INTERVAL = 60_000; // 1 min
+
+export class GHToken {
   token: string;
   valid?: boolean;
   remaining?: number;
   limit?: number;
   reset?: number;
+
   _lastValidated?: number;
   _app?: boolean;
   _appInstallationId?: string;
+
+  constructor(token: string, opts?: { app?: boolean; appInstallationId?: string }) {
+    this.token = token;
+    this._app = opts?.app;
+    this._appInstallationId = opts?.appInstallationId;
+  }
+
+  updateStatus(res: Response) {
+    this.remaining = Number.parseInt(res.headers.get("x-ratelimit-remaining") || "0");
+    this.limit = Number.parseInt(res.headers.get("x-ratelimit-limit") || "0");
+    this.valid = res.status !== 401;
+    const resetEpoch = res.headers.get("x-ratelimit-reset");
+    this.reset = resetEpoch ? Number.parseInt(resetEpoch) * 1000 : undefined;
+  }
+
+  // NOTE: Each call consumes one API request to fetch rate limit info.
+  async validate() {
+    try {
+      const res = await ofetch.raw("https://api.github.com/meta", {
+        ignoreResponseError: true,
+        headers: {
+          "User-Agent": "fetch",
+          Authorization: `token ${this.token}`,
+        },
+      });
+      this.updateStatus(res);
+      this._lastValidated = Date.now();
+      const resetInfo = this.reset ? ` resets in ${formatDuration(this.reset - Date.now())}` : "";
+      const resource = res.headers.get("x-ratelimit-resource") || "";
+      console.log(
+        `GitHub token ${this.valid ? "validated" : "invalid"} (${res.status}): ${this.remaining}/${this.limit}${resource ? ` [${resource}]` : ""}${resetInfo}`,
+      );
+    } catch (error) {
+      // Preserve last-known token state on transport errors (DNS/TLS/timeout)
+      console.error("Error validating GitHub token:", error);
+    }
+  }
+
+  /** Returns true if this token needs revalidation */
+  isStale(now = Date.now()) {
+    if (this.reset && this.reset > now) return false;
+    return !this._lastValidated || now - this._lastValidated > REVALIDATE_INTERVAL;
+  }
+
+  /** Clears expired rate limit state */
+  clearExpiredLimits(now = Date.now()) {
+    if (this.valid && this.remaining === 0 && this.reset && this.reset < now) {
+      this.remaining = undefined;
+      this.limit = undefined;
+      this.reset = undefined;
+    }
+  }
+
+  /** Whether this token is usable for requests */
+  get available() {
+    return this.valid && (this.remaining ?? 1) > 0;
+  }
 }
 
-export const ghTokens: GHToken[] = [];
+// --- Token registry ---
 
-let _tokensInitialized = false;
-let _tokensValidatePromise: Promise<void> | undefined;
+const runtimeConfig = useRuntimeConfig();
 
-export function ensureTokens() {
-  if (_tokensInitialized) return;
-  _tokensInitialized = true;
-  const runtimeConfig = useRuntimeConfig();
-  const tokens = ((runtimeConfig.GH_TOKEN as string) || "")
-    .split(",")
-    .map((token) => token.trim())
-    .filter(Boolean);
-  ghTokens.push(...tokens.map((token) => ({ token })));
-}
+export const ghTokens: GHToken[] = ((runtimeConfig.GH_TOKEN as string) || "")
+  .split(",")
+  .map((t) => t.trim())
+  .filter(Boolean)
+  .map((t) => new GHToken(t));
+
+let _validatePromise: Promise<void> | undefined;
 
 export function ensureTokensValidated() {
-  ensureTokens();
-  if (!_tokensValidatePromise) {
-    _tokensValidatePromise = Promise.all([validateGHTokens(), ensureAppToken()]).then(() => {});
+  if (!_validatePromise) {
+    _validatePromise = Promise.all([
+      Promise.all(ghTokens.map((t) => t.validate())),
+      _ensureAppToken(),
+    ]).then(() => {});
   }
-  return _tokensValidatePromise;
+  return _validatePromise;
 }
-
-// NOTE: Each call consumes one API request per token to fetch rate limit info.
-// Call this sparingly.
-async function validateGHToken(token: GHToken) {
-  try {
-    const res = await ofetch.raw("https://api.github.com/meta", {
-      ignoreResponseError: true,
-      headers: {
-        "User-Agent": "fetch",
-        Authorization: `token ${token.token}`,
-      },
-    });
-    updateTokenStatus(token, res);
-    token._lastValidated = Date.now();
-    const resetInfo = token.reset ? ` resets in ${formatDuration(token.reset - Date.now())}` : "";
-    const resource = res.headers.get("x-ratelimit-resource") || "";
-    console.log(
-      `GitHub token ${token.valid ? "validated" : "invalid"} (${res.status}): ${token.remaining}/${token.limit}${resource ? ` [${resource}]` : ""}${resetInfo}`,
-    );
-  } catch (error) {
-    // Preserve last-known token state on transport errors (DNS/TLS/timeout)
-    console.error("Error validating GitHub token:", error);
-  }
-}
-
-async function validateGHTokens() {
-  ensureTokens();
-  await Promise.all(ghTokens.map((token) => validateGHToken(token)));
-}
-
-const REVALIDATE_INTERVAL = 60_000; // 1 min
 
 let _revalidatePromise: Promise<boolean> | undefined;
 
@@ -85,42 +112,23 @@ export function revalidateGHTokens() {
 }
 
 async function _doRevalidateGHTokens() {
-  ensureTokens();
   const now = Date.now();
-  const staleTokens = ghTokens.filter(
-    (t) =>
-      (!t._lastValidated || now - t._lastValidated > REVALIDATE_INTERVAL) &&
-      (!t.reset || t.reset <= now),
-  );
+  const staleTokens = ghTokens.filter((t) => t.isStale(now));
   if (staleTokens.length === 0) {
     return false;
   }
-  await Promise.all(staleTokens.map((token) => validateGHToken(token)));
+  await Promise.all(staleTokens.map((t) => t.validate()));
   return true;
 }
 
 export function getGHToken() {
-  ensureTokens();
   const now = Date.now();
   for (const token of ghTokens) {
-    if (token.valid && token.remaining === 0 && token.reset && token.reset < now) {
-      token.remaining = undefined;
-      token.limit = undefined;
-      token.reset = undefined;
-    }
+    token.clearExpiredLimits(now);
   }
-  const validTokens = ghTokens
-    .filter((token) => token.valid && (token.remaining ?? 1) > 0)
-    .sort((a, b) => (b.remaining ?? 1) - (a.remaining ?? 1));
-  return validTokens[0];
-}
-
-export function updateTokenStatus(token: GHToken, res: Response) {
-  token.remaining = Number.parseInt(res.headers.get("x-ratelimit-remaining") || "0");
-  token.limit = Number.parseInt(res.headers.get("x-ratelimit-limit") || "0");
-  token.valid = res.status !== 401;
-  const resetEpoch = res.headers.get("x-ratelimit-reset");
-  token.reset = resetEpoch ? Number.parseInt(resetEpoch) * 1000 : undefined;
+  return ghTokens
+    .filter((t) => t.available)
+    .sort((a, b) => (b.remaining ?? 1) - (a.remaining ?? 1))[0];
 }
 
 export function formatDuration(ms: number) {
@@ -136,7 +144,7 @@ export function formatDuration(ms: number) {
 
 let _appTokenPromise: Promise<void> | undefined;
 
-export function ensureAppToken() {
+function _ensureAppToken() {
   if (!_appTokenPromise) {
     _appTokenPromise = _refreshAppToken();
   }
@@ -145,7 +153,6 @@ export function ensureAppToken() {
 
 async function _refreshAppToken() {
   try {
-    const runtimeConfig = useRuntimeConfig();
     const appId = runtimeConfig.GH_APP_ID as string;
     const privateKey = runtimeConfig.GH_APP_PRIVATE_KEY as string;
     if (!appId || !privateKey) {
@@ -154,7 +161,6 @@ async function _refreshAppToken() {
 
     const jwt = await _createAppJWT(appId, privateKey);
 
-    // Fetch installation IDs from the GitHub API
     const installations = await ofetch<{ id: number }[]>(
       "https://api.github.com/app/installations",
       {
@@ -198,12 +204,12 @@ async function _refreshAppToken() {
             existing.limit = undefined;
             existing.reset = undefined;
           } else {
-            ghTokens.push({
-              token: res.token,
-              valid: true,
-              _app: true,
-              _appInstallationId: installationId,
-            });
+            ghTokens.push(
+              new GHToken(res.token, {
+                app: true,
+                appInstallationId: installationId,
+              }),
+            );
           }
 
           const expiresAt = new Date(res.expires_at).getTime();
@@ -222,7 +228,6 @@ async function _refreshAppToken() {
       }),
     );
 
-    // Schedule refresh based on earliest expiry
     if (earliestRefresh < Number.POSITIVE_INFINITY) {
       setTimeout(() => {
         _appTokenPromise = _refreshAppToken();
@@ -257,7 +262,7 @@ export function _base64url(str: string): string {
   return _bufferToBase64url(new TextEncoder().encode(str));
 }
 
-function _bufferToBase64url(buf: ArrayBuffer): string {
+function _bufferToBase64url(buf: ArrayBuffer | Uint8Array): string {
   const bytes = new Uint8Array(buf);
   let binary = "";
   for (const byte of bytes) {
@@ -267,7 +272,6 @@ function _bufferToBase64url(buf: ArrayBuffer): string {
 }
 
 function _pemToKeyData(pem: string): ArrayBuffer {
-  // Normalize literal \n from env vars to real newlines
   const normalized = pem.replace(/\\n/g, "\n");
   const isPkcs1 = normalized.includes("BEGIN RSA PRIVATE KEY");
   const base64 = normalized
@@ -275,7 +279,6 @@ function _pemToKeyData(pem: string): ArrayBuffer {
     .replace(/-----END [\w ]+-----/, "")
     .replace(/\s/g, "");
   const der = _base64ToBinary(base64);
-  // Web Crypto requires PKCS#8; GitHub App keys are PKCS#1 — wrap if needed
   return isPkcs1 ? _pkcs1ToPkcs8(der) : der;
 }
 
@@ -288,16 +291,13 @@ function _base64ToBinary(base64: string): ArrayBuffer {
   return bytes.buffer as ArrayBuffer;
 }
 
-// Wraps a PKCS#1 RSA private key DER in the PKCS#8 ASN.1 envelope
 function _pkcs1ToPkcs8(pkcs1: ArrayBuffer): ArrayBuffer {
-  // PKCS#8 header for RSA: SEQUENCE { version INTEGER 0, algorithm AlgorithmIdentifier { OID rsaEncryption, NULL }, privateKey OCTET STRING { <pkcs1> } }
   const pkcs1Bytes = new Uint8Array(pkcs1);
-  // RSA OID (1.2.840.113549.1.1.1) + NULL params
   const algorithmId = new Uint8Array([
     0x30, 0x0d, 0x06, 0x09, 0x2a, 0x86, 0x48, 0x86, 0xf7, 0x0d, 0x01, 0x01, 0x01, 0x05, 0x00,
   ]);
-  const version = new Uint8Array([0x02, 0x01, 0x00]); // INTEGER 0
-  const octetString = _asn1Wrap(0x04, pkcs1Bytes); // OCTET STRING wrapping PKCS#1
+  const version = new Uint8Array([0x02, 0x01, 0x00]);
+  const octetString = _asn1Wrap(0x04, pkcs1Bytes);
   const totalLen = version.length + algorithmId.length + octetString.length;
   const seq = _asn1Wrap(0x30, _concat(version, algorithmId, octetString), totalLen);
   return seq.buffer as ArrayBuffer;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+import { resolve } from "node:path";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "~": resolve(import.meta.dirname, "."),
+    },
+  },
+});


### PR DESCRIPTION
When you fetch `https://ungh.cc/orgs/blablabla` for example, the internal github api would fail and then it would revalidate every token, which incurs one fetch for each of them unnecessarily, making it easy to exhaust the rate limit.

https://github.com/unjs/ungh/blob/de35d1a47bb51df29d420290a84459d4ce0da181/utils/github.ts#L63-L66

This PR removes that line and makes other refactors to properly revalidate the tokens, which I'll comment as reviews below.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Token checks now run only for stale tokens and concurrent requests share a single in-flight revalidation, reducing redundant validation and improving responsiveness.
  * Token registry is initialized eagerly to improve readiness at startup.

* **Bug Fixes**
  * Request handling simplified to avoid unnecessary validation attempts and prevent transient request errors from clearing known token state.
  * Token status is updated reliably from responses, reducing false rate-limit resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->