### PR TITLE
refactor: use /rate_limit for token validation

### DIFF
--- a/.agents/GH_API.md
+++ b/.agents/GH_API.md
@@ -23,17 +23,17 @@ Two files handle all GitHub API interaction:
 ## Token Lifecycle
 
 ```
-new GHToken(token)          -> valid=undefined, remaining=undefined
+new GHToken(token)                      -> valid=undefined, remaining=undefined
   |
-validate()                  -> calls GET /meta, sets valid/remaining/limit/reset
+validate()                              -> calls GET /rate_limit, sets valid/remaining/limit/reset
   |
-updateStatus(response)      -> called on every ghFetch response to keep rate limits current
+updateStatusFromResponse(response)      -> called on every ghFetch response to keep rate limits current
   |
-isStale()                   -> true if: no lastValidated, or >1min since last validation
-                               (skips revalidation if reset is still in the future)
+isStale()                               -> true if: no lastValidated, or >1min since last validation
+                                           (skips revalidation if reset is still in the future)
   |
-clearExpiredLimits()        -> once reset time passes, clears remaining/limit/reset
-                               so the token becomes available again (remaining ?? 1 > 0)
+clearExpiredLimits()                    -> once reset time passes, clears remaining/limit/reset
+                                           so the token becomes available again (remaining ?? 1 > 0)
 ```
 
 ## Token Acquisition (`acquireGHToken`)
@@ -60,7 +60,7 @@ Subsequent requests rely on `revalidateGHTokens()` (called from `acquireGHToken`
 
 Runs once via `idempotent()` wrapper (`once: true`):
 
-1. Validate all PAT tokens in parallel (each calls GET /meta — costs 1 API request)
+1. Validate all PAT tokens in parallel (each calls GET /rate_limit — costs 0 API request)
 2. Bootstrap App tokens (JWT -> list installations -> create installation tokens)
 
 ## Revalidation (`revalidateGHTokens`)
@@ -75,7 +75,7 @@ Runs once via `idempotent()` wrapper (`once: true`):
 - Wraps `fetch` with GitHub auth headers
 - Uses `defineCachedFunction` (6h maxAge, 12h staleMaxAge, no SWR)
 - Calls `acquireGHToken()` to get a token; if none returned, throws 403 with diagnostic info (invalid count, exhausted count, soonest reset time)
-- On every response, updates the token's rate limit via `onResponse` → `token.updateStatus()`
+- On every response, updates the token's rate limit via `onResponse` → `token.updateStatusFromResponse()`
 - Cache validation rejects empty arrays and zero-count results
 
 ## Helper Endpoints
@@ -104,5 +104,5 @@ Used by: `ensureTokensValidated` (once), `ensureAllTokensValidated` (once), `ens
 - `remaining ?? 1` in `available` getter — treats never-checked tokens as available (optimistic until proven otherwise)
 - App token refresh is self-scheduling via `setTimeout`, not driven by requests
 - Transport errors in `validate()` preserve last-known state (no flip to invalid)
-- `updateStatus()` only updates `remaining`/`limit`/`reset` when their respective headers are present — avoids losing known state on responses lacking rate limit headers
+- `updateStatusFromResponse()` only updates `remaining`/`limit`/`reset` when their respective headers are present — avoids losing known state on responses lacking rate limit headers
 - `isStale()` always returns `true` for never-validated tokens (`_lastValidated` undefined), even if `reset` is somehow set — prevents edge case where a token could become permanently non-revalidatable

--- a/test/github_token.test.ts
+++ b/test/github_token.test.ts
@@ -599,7 +599,7 @@ describe("ensureAllTokensValidated", () => {
 
   it("validates all tokens", async () => {
     ghTokens.push(new GHToken("tok1"), new GHToken("tok2"));
-    fetchSpy.mockResolvedValue(mockResponse(200, rateLimitHeaders(3000, 5000)));
+    fetchSpy.mockResolvedValue(mockRateLimitResponse(3000, 5000));
     await ensureAllTokensValidated();
     expect(ghTokens[0]!.valid).toBe(true);
     expect(ghTokens[1]!.valid).toBe(true);
@@ -641,7 +641,7 @@ describe("revalidateGHTokens", () => {
     const t = new GHToken("tok");
     t._lastValidated = Date.now() - 120_000;
     ghTokens.push(t);
-    fetchSpy.mockResolvedValue(mockResponse(200, rateLimitHeaders(4000, 5000)));
+    fetchSpy.mockResolvedValue(mockRateLimitResponse(4000, 5000));
     const [r1, r2] = await Promise.all([revalidateGHTokens(), revalidateGHTokens()]);
     expect(r1).toBe(r2);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -663,14 +663,14 @@ describe("acquireGHToken", () => {
   it("returns the best available token after validation", async () => {
     const t = new GHToken("tok");
     ghTokens.push(t);
-    fetchSpy.mockResolvedValue(mockResponse(200, rateLimitHeaders(4000, 5000)));
+    fetchSpy.mockResolvedValue(mockRateLimitResponse(4000, 5000));
     expect(await acquireGHToken()).toBe(t);
     expect(t.valid).toBe(true);
   });
 
   it("returns undefined when all tokens are invalid", async () => {
     ghTokens.push(new GHToken("tok"));
-    fetchSpy.mockResolvedValue(mockResponse(401, rateLimitHeaders(0, 0)));
+    fetchSpy.mockResolvedValue(mockResponse(401));
     expect(await acquireGHToken()).toBeUndefined();
   });
 
@@ -681,9 +681,9 @@ describe("acquireGHToken", () => {
     fetchSpy.mockImplementation(async () => {
       callCount++;
       if (callCount <= 1) {
-        return mockResponse(200, rateLimitHeaders(0, 5000, Math.floor(Date.now() / 1000) - 1));
+        return mockRateLimitResponse(0, 5000, Math.floor(Date.now() / 1000) - 1);
       }
-      return mockResponse(200, rateLimitHeaders(4000, 5000));
+      return mockRateLimitResponse(4000, 5000);
     });
     expect(await acquireGHToken()).toBe(t);
   });

--- a/test/github_token.test.ts
+++ b/test/github_token.test.ts
@@ -19,6 +19,25 @@ function mockResponse(status: number, headers: Record<string, string> = {}): Res
   return new Response(null, { status, headers });
 }
 
+function mockRateLimitResponse(remaining: number, limit: number, resetEpoch?: number): Response {
+  return new Response(
+    JSON.stringify({
+      resources: {
+        core: {
+          limit,
+          used: limit - remaining,
+          remaining,
+          reset: resetEpoch,
+        },
+      },
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}
+
 function rateLimitHeaders(
   remaining: number,
   limit: number,
@@ -60,6 +79,9 @@ function mockAppFetch(
     installationsStatus?: number;
     accessToken?: { token: string; expires_at: string };
     accessTokenStatus?: number;
+    rateLimit?: {
+      resources: Record<string, { limit: number; used: number; remaining: number; reset: number }>;
+    };
   } = {},
 ) {
   const {
@@ -70,6 +92,16 @@ function mockAppFetch(
       expires_at: new Date(Date.now() + 3600_000).toISOString(),
     },
     accessTokenStatus = 200,
+    rateLimit = {
+      resources: {
+        core: {
+          limit: 5000,
+          used: 500,
+          remaining: 4500,
+          reset: Math.floor(Date.now() / 1000) + 3600,
+        },
+      },
+    },
   } = opts;
 
   fetchSpy.mockImplementation(async (url: string | URL | Request) => {
@@ -89,19 +121,24 @@ function mockAppFetch(
         headers: { "Content-Type": "application/json" },
       });
     }
-    // validate call (/meta)
-    return mockResponse(200, rateLimitHeaders(4500, 5000));
+    if (urlStr.includes("/rate_limit")) {
+      return new Response(JSON.stringify(rateLimit), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    throw new Error(`Unexpected fetch to ${urlStr} in mockAppFetch`);
   });
 }
 
 // --- GHToken class ---
 
 describe("GHToken", () => {
-  describe("updateStatus", () => {
+  describe("updateStatusFromResponse", () => {
     it("parses rate limit headers from successful response", () => {
       const token = new GHToken("test-token");
       const resetEpoch = Math.floor(Date.now() / 1000) + 3600;
-      token.updateStatus(mockResponse(200, rateLimitHeaders(4999, 5000, resetEpoch)));
+      token.updateStatusFromResponse(mockResponse(200, rateLimitHeaders(4999, 5000, resetEpoch)));
 
       expect(token.valid).toBe(true);
       expect(token.remaining).toBe(4999);
@@ -111,21 +148,21 @@ describe("GHToken", () => {
 
     it("marks token invalid on 401", () => {
       const token = new GHToken("bad-token");
-      token.updateStatus(mockResponse(401, rateLimitHeaders(0, 0)));
+      token.updateStatusFromResponse(mockResponse(401, rateLimitHeaders(0, 0)));
       expect(token.valid).toBe(false);
       expect(token.remaining).toBe(0);
     });
 
     it("marks token valid on 403 (rate limited, not auth failure)", () => {
       const token = new GHToken("test-token");
-      token.updateStatus(mockResponse(403, rateLimitHeaders(0, 5000)));
+      token.updateStatusFromResponse(mockResponse(403, rateLimitHeaders(0, 5000)));
       expect(token.valid).toBe(true);
       expect(token.remaining).toBe(0);
     });
 
     it("handles missing reset header", () => {
       const token = new GHToken("test-token");
-      token.updateStatus(mockResponse(200, rateLimitHeaders(100, 5000)));
+      token.updateStatusFromResponse(mockResponse(200, rateLimitHeaders(100, 5000)));
       expect(token.reset).toBeUndefined();
     });
   });
@@ -139,14 +176,9 @@ describe("GHToken", () => {
       fetchSpy.mockRestore();
     });
 
-    it("updates status from /meta response", async () => {
+    it("updates status from /rate_limit response", async () => {
       const resetEpoch = Math.floor(Date.now() / 1000) + 3600;
-      fetchSpy.mockResolvedValueOnce(
-        mockResponse(200, {
-          ...rateLimitHeaders(4500, 5000, resetEpoch),
-          "x-ratelimit-resource": "core",
-        }),
-      );
+      fetchSpy.mockResolvedValueOnce(mockRateLimitResponse(4500, 5000, resetEpoch));
 
       const token = new GHToken("test-token");
       await token.validate();
@@ -154,13 +186,14 @@ describe("GHToken", () => {
       expect(token.valid).toBe(true);
       expect(token.remaining).toBe(4500);
       expect(token.limit).toBe(5000);
+      expect(token.reset).toBe(resetEpoch * 1000);
       expect(token._lastValidated).toBeTypeOf("number");
       expect(fetchSpy).toHaveBeenCalledOnce();
-      expect(fetchSpy.mock.calls[0]![0]).toMatch(/api\.github\.com\/meta/);
+      expect(fetchSpy.mock.calls[0]![0]).toMatch(/api\.github\.com\/rate_limit/);
     });
 
     it("marks token invalid on 401 response", async () => {
-      fetchSpy.mockResolvedValueOnce(mockResponse(401, rateLimitHeaders(0, 0)));
+      fetchSpy.mockResolvedValueOnce(mockResponse(401));
       const token = new GHToken("bad-token");
       await token.validate();
       expect(token.valid).toBe(false);
@@ -179,7 +212,7 @@ describe("GHToken", () => {
     });
 
     it("sends authorization header", async () => {
-      fetchSpy.mockResolvedValueOnce(mockResponse(200, rateLimitHeaders(5000, 5000)));
+      fetchSpy.mockResolvedValueOnce(mockRateLimitResponse(5000, 5000));
       const token = new GHToken("ghp_secret123");
       await token.validate();
       const [, init] = fetchSpy.mock.calls[0]!;
@@ -532,7 +565,7 @@ describe("ensureTokensValidated", () => {
 
   it("validates tokens until one is available", async () => {
     ghTokens.push(new GHToken("tok1"), new GHToken("tok2"));
-    fetchSpy.mockResolvedValue(mockResponse(200, rateLimitHeaders(4000, 5000)));
+    fetchSpy.mockResolvedValue(mockRateLimitResponse(4000, 5000));
     await ensureTokensValidated();
     expect(ghTokens[0]!.valid).toBe(true);
     expect(ghTokens[0]!.remaining).toBe(4000);
@@ -540,7 +573,7 @@ describe("ensureTokensValidated", () => {
 
   it("falls back to revalidation when no token is available", async () => {
     ghTokens.push(new GHToken("tok"));
-    fetchSpy.mockResolvedValue(mockResponse(401, rateLimitHeaders(0, 0)));
+    fetchSpy.mockResolvedValue(mockResponse(401));
     await ensureTokensValidated();
     expect(ghTokens[0]!.valid).toBe(false);
     expect(fetchSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
@@ -589,7 +622,7 @@ describe("revalidateGHTokens", () => {
     t.valid = true;
     t._lastValidated = Date.now() - 120_000;
     ghTokens.push(t);
-    fetchSpy.mockResolvedValue(mockResponse(200, rateLimitHeaders(4500, 5000)));
+    fetchSpy.mockResolvedValue(mockRateLimitResponse(4500, 5000));
     expect(await revalidateGHTokens()).toBe(true);
     expect(t.remaining).toBe(4500);
   });

--- a/utils/github.ts
+++ b/utils/github.ts
@@ -45,7 +45,7 @@ export const ghFetch = defineCachedFunction(
         ...opts.headers,
       },
     });
-    token.updateStatus(res);
+    token.updateStatusFromResponse(res);
     if (!res.ok) {
       throw new HTTPError({
         message: `GitHub API error: ${res.status} ${res.statusText}`,

--- a/utils/github_token.ts
+++ b/utils/github_token.ts
@@ -58,8 +58,8 @@ export class GHToken {
         Authorization: `token ${this.token}`,
       },
     });
-    this.valid = res.ok;
-    if (this.valid) {
+    this.valid = res.status !== 401;
+    if (res.ok) {
       const data = await res.json();
       this.remaining = data.resources.core.remaining;
       this.limit = data.resources.core.limit;

--- a/utils/github_token.ts
+++ b/utils/github_token.ts
@@ -41,7 +41,7 @@ export class GHToken {
     return `[GitHub ${type} token ${this.maskedToken}]`;
   }
 
-  updateStatus(res: Response) {
+  updateStatusFromResponse(res: Response) {
     this.valid = res.status !== 401;
     const remaining = res.headers.get("x-ratelimit-remaining");
     const limit = res.headers.get("x-ratelimit-limit");
@@ -51,21 +51,29 @@ export class GHToken {
     if (resetEpoch) this.reset = Number.parseInt(resetEpoch) * 1000;
   }
 
-  /** NOTE: Each call consumes one API request to fetch rate limit info. */
+  async updateStatusFromRateLimitEndpoint() {
+    const res = await fetch("https://api.github.com/rate_limit", {
+      headers: {
+        "User-Agent": "fetch",
+        Authorization: `token ${this.token}`,
+      },
+    });
+    this.valid = res.ok;
+    if (this.valid) {
+      const data = await res.json();
+      this.remaining = data.resources.core.remaining;
+      this.limit = data.resources.core.limit;
+      this.reset = data.resources.core.reset * 1000;
+    }
+  }
+
   async validate() {
     try {
-      const res = await fetch("https://api.github.com/meta", {
-        headers: {
-          "User-Agent": "fetch",
-          Authorization: `token ${this.token}`,
-        },
-      });
-      this.updateStatus(res);
+      await this.updateStatusFromRateLimitEndpoint();
       this._lastValidated = Date.now();
       const resetInfo = this.reset ? ` resets in ${formatDuration(this.reset - Date.now())}` : "";
-      const resource = res.headers.get("x-ratelimit-resource") || "";
       console.log(
-        `GitHub token ${this.valid ? "validated" : "invalid"} (${res.status}): ${this.remaining}/${this.limit}${resource ? ` [${resource}]` : ""}${resetInfo}`,
+        `GitHub token ${this.valid ? "validated" : "invalid"}: ${this.remaining}/${this.limit} [core]${resetInfo}`,
       );
     } catch (error) {
       // Preserve last-known token state on transport errors (DNS/TLS/timeout)
@@ -133,7 +141,9 @@ async function _validateUntilOneAvailable() {
  * Concurrent callers share the same in-flight promise (coalesced, not once).
  * Returns true if any tokens were revalidated.
  */
-export const revalidateGHTokens = idempotent(_doRevalidateGHTokens, { once: false });
+export const revalidateGHTokens = idempotent(_doRevalidateGHTokens, {
+  once: false,
+});
 
 async function _doRevalidateGHTokens() {
   const now = Date.now();
@@ -177,7 +187,11 @@ export function getAggregateRateLimit() {
   const soonestReset = ghTokens
     .filter((t) => t.valid && t.reset)
     .sort((a, b) => (a.reset || 0) - (b.reset || 0))[0];
-  return { remaining: totalRemaining, limit: totalLimit, reset: soonestReset?.reset };
+  return {
+    remaining: totalRemaining,
+    limit: totalLimit,
+    reset: soonestReset?.reset,
+  };
 }
 
 /** Max jitter (in seconds) added to Retry-After to spread out retry storms. */
@@ -203,7 +217,9 @@ export function formatDuration(ms: number) {
 // --- GitHub App token ---
 
 /** Bootstraps GitHub App installation tokens (samples up to 5 random installations). Coalesced (not once). */
-export const ensureAppToken = idempotent(() => _refreshAppToken(false), { once: false });
+export const ensureAppToken = idempotent(() => _refreshAppToken(false), {
+  once: false,
+});
 
 /** Bootstraps all GitHub App installation tokens (once). Used by the status page. */
 const _ensureAllAppTokensOnce = idempotent(() => _refreshAppToken(true));


### PR DESCRIPTION
This PR uses `/rate_limit` endpoint for token validation as the endpoint doesn't count against the limit compared to `/meta`.

This means we're free to refresh the status page without any impact, though perhaps we still want to put it behind auth to prevent abuse. It also means we can easily show the rate limit for other github apis, like graphql, in the future.

With this PR, there's `updateStatusFromResponse` and `updateStatusFromRateLimitEndpoint` to update the token status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated GitHub token lifecycle docs to reflect a switch to the rate-limit endpoint and the validation step costing 0 API requests.

* **Refactor**
  * Reworked per-response and validation flows for more accurate rate-limit synchronization and clearer validation logging.

* **Tests**
  * Updated test mocks and suites to align with the new validation approach and rate-limit responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->