### PR TITLE
feat: support get repository release by tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,29 @@ Get latest repository release.
 }
 ```
 
+### `/repos/{owner}/{name}/releases/tags/{tag}`
+
+Get repository release by tag.
+
+**Example:** https://ungh.cc/repos/nuxt/framework/releases/tags/v3.0.0-rc.13
+
+```json
+{
+  "release": {
+    "id": 82066265,
+    "tag": "v3.0.0-rc.13",
+    "author": "pi0",
+    "name": "v3.0.0-rc.13",
+    "draft": false,
+    "prerelease": false,
+    "createdAt": "2022-11-04T11:37:49Z",
+    "publishedAt": "2022-11-04T11:41:59Z",
+    "markdown": "....",
+    "html": "..."
+  }
+}
+```
+
 ### `/repos/{owner}/{name}/branches`
 
 Get all the branches of a repository

--- a/routes/repos/[owner]/[repo]/releases/tags/[tag].ts
+++ b/routes/repos/[owner]/[repo]/releases/tags/[tag].ts
@@ -1,0 +1,63 @@
+import { defineRouteMeta, defineHandler } from "nitro";
+import { ghFetch, ghMarkdown } from "~/utils/github";
+import type { GithubRelease } from "~types";
+
+defineRouteMeta({
+  openAPI: {
+    description: "Get repository release by tag.",
+    parameters: [
+      {
+        name: "owner",
+        in: "path",
+        required: true,
+        schema: { type: "string", example: "unjs" },
+      },
+      {
+        name: "repo",
+        in: "path",
+        required: true,
+        schema: { type: "string", example: "ofetch" },
+      },
+      {
+        name: "tag",
+        in: "path",
+        required: true,
+        schema: { type: "string", example: "v1.5.0" },
+      },
+    ],
+  },
+});
+
+export default defineHandler(async (event) => {
+  const repo = `${event.context.params!.owner}/${event.context.params!.repo}`;
+  const tag = event.context.params!.tag;
+  const i = await ghFetch(`repos/${repo}/releases/tags/${tag}`);
+
+  const release: GithubRelease = {
+    id: i.id,
+    tag: i.tag_name,
+    author: i.author.login,
+    name: i.name,
+    draft: i.draft,
+    prerelease: i.prerelease,
+    createdAt: i.created_at,
+    publishedAt: i.published_at,
+    markdown: i.body,
+    html: await ghMarkdown(i.body, repo, "release-" + i.tag),
+    assets:
+      "assets" in i
+        ? i.assets.map((a: any) => ({
+            contentType: a.content_type,
+            size: a.size,
+            createdAt: a.created_at,
+            updatedAt: a.updated_at,
+            downloadCount: a.download_count,
+            downloadUrl: a.browser_download_url,
+          }))
+        : [],
+  };
+
+  return {
+    release,
+  };
+});


### PR DESCRIPTION
#161


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added a new API endpoint for fetching repository releases by specific tag. Returns comprehensive release metadata including author information, creation and publication timestamps, draft and prerelease status indicators, markdown and HTML-formatted content, and detailed information about associated release assets including file size, content type, and download metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->