### PR TITLE
feat: adding pagination for releases

### DIFF
--- a/nitro.config.ts
+++ b/nitro.config.ts
@@ -15,6 +15,14 @@ export default defineNitroConfig({
       cors: true,
       headers: isProduction ? { "access-control-max-age": "21600" } : {}, // 6 hours
     },
+    "repos/*/*/releases": {
+      isr: {
+        allowQuery: ["page"],
+        expiration: isProduction ? 60 * 60 * 6 : false,
+      },
+      cors: true,
+      headers: isProduction ? { "access-control-max-age": "21600" } : {}, // 6 hours
+    },
     "/_status": {
       cache: false,
       basicAuth: parseBasicAuth(process.env.STATUS_AUTH) || false,

--- a/nitro.config.ts
+++ b/nitro.config.ts
@@ -15,7 +15,7 @@ export default defineNitroConfig({
       cors: true,
       headers: isProduction ? { "access-control-max-age": "21600" } : {}, // 6 hours
     },
-    "repos/*/*/releases": {
+    "/repos/*/*/releases": {
       isr: {
         allowQuery: ["page"],
         expiration: isProduction ? 60 * 60 * 6 : false,

--- a/nitro.config.ts
+++ b/nitro.config.ts
@@ -16,10 +16,13 @@ export default defineNitroConfig({
       headers: isProduction ? { "access-control-max-age": "21600" } : {}, // 6 hours
     },
     "/repos/*/*/releases": {
-      isr: {
-        allowQuery: ["page"],
-        expiration: isProduction ? 60 * 60 * 6 : false,
-      },
+      isr: isProduction
+        ? {
+            allowQuery: ["page"],
+            passQuery: true,
+            expiration: 60 * 60 * 6,
+          }
+        : false,
       cors: true,
       headers: isProduction ? { "access-control-max-age": "21600" } : {}, // 6 hours
     },

--- a/routes/repos/[owner]/[repo]/releases/index.ts
+++ b/routes/repos/[owner]/[repo]/releases/index.ts
@@ -32,10 +32,10 @@ defineRouteMeta({
 
 export default defineHandler(async (event) => {
   const { page } = getQuery(event);
-  // first validating page, if it's present make sure it's a positive interger, else throw an http error to prevent a cache
+  // first validating page, if it's present make sure it's a positive integer, else throw an http error to prevent a cache
   const pageNr = Number(page);
   if (page && (!Number.isInteger(pageNr) || pageNr < 1)) {
-    throw new HTTPError("`page` can only be 1 or higher interger or omitted", { status: 400 });
+    throw new HTTPError("`page` can only be 1 or higher integer or omitted", { status: 400 });
   }
   // return typeof page;
   const repo = `${event.context.params!.owner}/${event.context.params!.repo}`;

--- a/routes/repos/[owner]/[repo]/releases/index.ts
+++ b/routes/repos/[owner]/[repo]/releases/index.ts
@@ -1,5 +1,7 @@
 import { defineRouteMeta, defineHandler } from "nitro";
+import { getQuery, HTTPError } from "nitro/h3";
 import { ghFetch, ghMarkdown } from "~/utils/github";
+import { withQuery } from "ufo";
 import type { GithubRelease } from "~types";
 
 defineRouteMeta({
@@ -18,13 +20,26 @@ defineRouteMeta({
         required: true,
         schema: { type: "string", example: "ofetch" },
       },
+      {
+        name: "page",
+        in: "query",
+        required: false,
+        schema: { type: "number", example: "2" },
+      },
     ],
   },
 });
 
 export default defineHandler(async (event) => {
+  const { page } = getQuery(event);
+  // first validating page, if it's present make sure it's a positive interger, else throw an http error to prevent a cache
+  const pageNr = Number(page);
+  if (page && (!Number.isInteger(pageNr) || pageNr < 1)) {
+    throw new HTTPError("`page` can only be 1 or higher interger or omitted", { status: 400 });
+  }
+  // return typeof page;
   const repo = `${event.context.params!.owner}/${event.context.params!.repo}`;
-  const res = await ghFetch(`/repos/${repo}/releases`);
+  const res = await ghFetch(withQuery(`/repos/${repo}/releases`, { page: pageNr }));
 
   const releases = res.map(
     (i: any) =>

--- a/routes/repos/[owner]/[repo]/releases/index.ts
+++ b/routes/repos/[owner]/[repo]/releases/index.ts
@@ -24,7 +24,7 @@ defineRouteMeta({
         name: "page",
         in: "query",
         required: false,
-        schema: { type: "number", example: "2" },
+        schema: { type: "integer", minimum: 1, example: 2 },
       },
     ],
   },
@@ -39,7 +39,7 @@ export default defineHandler(async (event) => {
   }
   // return typeof page;
   const repo = `${event.context.params!.owner}/${event.context.params!.repo}`;
-  const res = await ghFetch(withQuery(`/repos/${repo}/releases`, { page: pageNr }));
+  const res = await ghFetch(withQuery(`/repos/${repo}/releases`, { page }));
 
   const releases = res.map(
     (i: any) =>


### PR DESCRIPTION
relates to [#74](https://github.com/unjs/ungh/issues/74#issuecomment-4096501913), in specific for releases

I've added pagination to the releases endpoint, the following changes have been made:
* added the possibility to add `?page` query parameter to the releases handler
   * also added validation to check if `page` is a 1+ integer or omitted, if not an http error is throw to prevent caching
* added the releases endpoint to the nitro config to allow the `page` query for vercel and to have it cached by vercel.

I decided to not add `per_page` too, by keeping the default 30 it'll allow cache to stay simple

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pagination support for repository release listings.
  - Release listings accept an optional page number and request the corresponding results.
  - Enabled six-hour caching for release listings in production.
  - Preserved cross-origin access for the endpoint.

- **Bug Fixes**
  - Invalid page values now return a clear HTTP 400 error.
  - Caching is disabled during development to ensure current data is shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->